### PR TITLE
Allow  OIDC Configuration via env var

### DIFF
--- a/patientsearch/config.py
+++ b/patientsearch/config.py
@@ -1,11 +1,20 @@
+import json
 import os
+
+
+def decode_json_config(potential_json_string):
+    """Detect if given string is JSON file, or JSON string"""
+    if potential_json_string.endswith('.json'):
+        return potential_json_string
+    return json.loads(potential_json_string)
+
 
 SERVER_NAME = os.getenv("SERVER_NAME")
 SECRET_KEY = os.getenv("SECRET_KEY")
 EXTERNAL_FHIR_API = os.getenv("EXTERNAL_FHIR_API")
 MAP_API = os.getenv("MAP_API")
 
-OIDC_CLIENT_SECRETS = 'client_secrets.json'
+OIDC_CLIENT_SECRETS = decode_json_config(os.getenv("OIDC_CLIENT_SECRETS", "client_secrets.json"))
 OIDC_ID_TOKEN_COOKIE_SECURE = False
 OIDC_REQUIRE_VERIFIED_EMAIL = False
 OIDC_SCOPES = ['email', 'openid', 'roles']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flask
-flask-oidc
+# pin to last hash of master, to remove requirement of freestanding JSON config file
+git+https://github.com/puiterwijk/flask-oidc.git@7f16e27#egg=flask-oidc
 gunicorn
 requests


### PR DESCRIPTION
* Pin flask-oidc to unreleased version for [config ergonomics](https://github.com/puiterwijk/flask-oidc/blob/master/flask_oidc/__init__.py#L190-L196)
* Add helper function to read env var to dict
