### PR TITLE
Mark patients found on PDMP query with an identifier within fEMR's HAPI

### DIFF
--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -215,7 +215,7 @@ def external_search(resource_type):
         bundle=external_request(token, resource_type, request.args),
         resource_type=resource_type,
         identifier={
-            'system': current_app.config.get('EXTERNAL_FHIR_API'),
+            'system': 'https://github.com/uwcirg/script-fhir-facade',
             'value': 'found'})
 
     local_fhir_patient = sync_bundle(token, external_search_bundle)

--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -191,7 +191,7 @@ def resource_from_args(resource_type, args):
 
 
 @api_blueprint.route(
-    '/external_search/<string:resource_type>', methods=["GET", "PUT"])
+    '/external_search/<string:resource_type>', methods=["PUT"])
 def external_search(resource_type):
     """Query external source for resource_type
 

--- a/patientsearch/models/__init__.py
+++ b/patientsearch/models/__init__.py
@@ -1,10 +1,19 @@
 from .bearer_auth import BearerAuth
-from .sync import HAPI_POST, HAPI_request, external_request, sync_bundle
+from .sync import (
+    HAPI_POST,
+    HAPI_PUT,
+    HAPI_request,
+    add_identifier_to_resource_type,
+    external_request,
+    sync_bundle
+)
 
 __all__ = [
     'BearerAuth',
     'HAPI_POST',
+    'HAPI_PUT',
     'HAPI_request',
+    'add_identifier_to_resource_type',
     'external_request',
     'sync_bundle',
 ]

--- a/patientsearch/models/sync.py
+++ b/patientsearch/models/sync.py
@@ -1,8 +1,29 @@
 """Manages synchronization of Model data, between external and internal stores"""
+from copy import deepcopy
+
 from flask import abort, current_app
 from jmespath import search as json_search
 import requests
 from .bearer_auth import BearerAuth
+
+
+def add_identifier_to_resource_type(bundle, resource_type, identifier):
+    result = deepcopy(bundle)
+    for resource in result['entry']:
+        if resource.get('resourceType') != resource_type:
+            continue
+        identifiers = resource.get('identifier', [])
+        found = False
+        for i in identifiers:
+            if (
+                    i.get('system', '') == identifier.system and
+                    i.get('value', '') == identifier.value):
+                found = True
+                break
+        if not found:
+            identifiers.append(identifier)
+            resource['identifier'] = identifiers
+    return result
 
 
 def HAPI_request(token, resource_type, resource_id=None, params=None):
@@ -38,6 +59,25 @@ def HAPI_POST(token, resource):
     url = f"{current_app.config.get('MAP_API')}{resource_type}"
 
     resp = requests.post(url, auth=BearerAuth(token), json=resource)
+    try:
+        resp.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        abort(err.response.status_code, err)
+    return resp.json()
+
+
+def HAPI_PUT(token, resource):
+    """PUT to HAPI on configured system - return JSON
+
+    :param token: validated JWT to include in request for auth
+    :param resource: FHIR resource to PUT
+    :returns: result returned from HAPI
+
+    """
+    resource_type = resource['resourceType']
+    url = f"{current_app.config.get('MAP_API')}{resource_type}"
+
+    resp = requests.put(url, auth=BearerAuth(token), json=resource)
     try:
         resp.raise_for_status()
     except requests.exceptions.HTTPError as err:
@@ -95,33 +135,62 @@ def sync_bundle(token, bundle):
         return patient
 
 
+def _merge_patient(src_patient, internal_patient, token):
+    """Helper used to push details from src into internal patient"""
+    # TODO consider additional patient attributes beyond identifiers
+
+    def different(src, dest):
+        """returns true if details of interest found to be different"""
+        if src == dest:
+            return False
+        if src.get('identifier') is None:
+            return False
+        src_ids = set(
+            [f"{id['system']}|{id['value']}" for id in src.get('identifier', [])])
+        dest_ids = set(
+            [f"{id['system']}|{id['value']}" for id in dest.get('identifier', [])])
+        if src_ids == dest_ids:
+            return False
+        return True
+
+    if not different(src_patient, internal_patient):
+        return internal_patient
+    else:
+        internal_patient['identifier'] = src_patient['identifier']
+        return HAPI_PUT(token, internal_patient)
+
+
 def sync_patient(token, patient):
     """Sync single patient resource - insert or update as needed"""
     # Use same parameters sent to external src looking for existing Patient
+    # Note FHIR uses list for 'given', common parameter use defines just one
     search_map = (
         ('name.family', 'family', ''),
         ('name.given', 'given', ''),
+        ('name.given[0]', 'given', ''),
         ('birthDate', 'birthdate', 'eq')
     )
     search_params = {}
 
     for path, queryterm, compstr in search_map:
         match = json_search(path, patient)
-        if match:
+        if match and isinstance(match, str):
             search_params[queryterm] = compstr + match
 
     internal_search = HAPI_request(
         token=token, resource_type='Patient', params=search_params)
 
-    # If found, return the Patient
+    # If found, return the Patient, merging if necessary
     match_count = internal_search['total']
     if match_count > 0:
         if match_count > 1:
             current_app.logger.warn(
                 f"expected ONE matching patient, found {match_count}")
 
-        # TODO: manage sync issues when both exist and multiple matches
-        return internal_search['entry'][0]['resource']
+        internal_patient = internal_search['entry'][0]['resource']
+        merged_patient = _merge_patient(
+            src_patient=patient, internal_patient=internal_patient, token=token)
+        return merged_patient
 
     # No match, insert and return
     return HAPI_POST(token, patient)

--- a/tests/test_sync/external_patient_search.json
+++ b/tests/test_sync/external_patient_search.json
@@ -5,7 +5,7 @@
       "gender": "male",
       "name": {
         "family": "skywalker",
-        "given": "luke"
+        "given": ["luke"]
       },
       "resourceType": "Patient"
     }


### PR DESCRIPTION
- Mark patients found on PDMP query with an identifier within fEMR's HAPI.
- Implement initial `sync_patient` to bring `identifier` changes into local HAPI store.

@achen2401  I'll note, once this is merged, the front end can start to make use of the identifier, to group the PDMP known patients vs those not found.  It will be necessary to successfully find each in turn via the patient search [GO] process to bring the identifier in...