### PR TITLE
backend can't redirect during validation check - return 401 for frontend redirect

### DIFF
--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -54,11 +54,12 @@ def validate_auth():
         token = oidc.get_access_token()
     except TypeError:
         # raised when the token isn't accessible to the oidc lib
-        return redirect("/")
+        terminate_session()
+        raise Unauthorized("oidc access token inaccessible")
 
     if not oidc.validate_token(token):
         terminate_session()
-        return redirect("/")
+        raise Unauthorized("oidc token invalid")
     return token
 
 

--- a/patientsearch/models/sync.py
+++ b/patientsearch/models/sync.py
@@ -184,7 +184,7 @@ def sync_patient(token, patient):
     match_count = internal_search['total']
     if match_count > 0:
         if match_count > 1:
-            current_app.logger.warn(
+            current_app.logger.warning(
                 f"expected ONE matching patient, found {match_count}")
 
         internal_patient = internal_search['entry'][0]['resource']

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -42,7 +42,7 @@ export default function TimeoutModal() {
     /*
      * when the expires in is less than the next track interval, the session will have expired, so just logout user
      */
-    if (expiresIn && 
+    if (expiresIn &&
       expiresIn > 0 &&
       expiresIn <= (trackInterval/1000)) {
         handleLogout();
@@ -55,7 +55,7 @@ export default function TimeoutModal() {
           tokenData = JSON.parse(response);
           //in seconds
           expiresIn = tokenData["expires_in"];
-         
+
           if (!tokenData["valid"] || expiresIn <= 1) {
             handleLogout();
             return;
@@ -64,7 +64,7 @@ export default function TimeoutModal() {
             cleanUpModal();
             if (!open) handleOpen();
           }
- 
+
         } catch(e) {
           console.log(`Error occurred parsing token data ${e}`);
           clearExpiredIntervalId();
@@ -74,13 +74,14 @@ export default function TimeoutModal() {
       }
     },
     error => {
-      if (error.status && error.status == 401) {
+      console.log("Error returned ", error);
+      if (error && error.status && error.status == 401) {
         console.log("Failed to retriev token data: Unauthorized ");
         handleLogout();
         return;
       }
       clearExpiredIntervalId();
-      console.log("Failed to retrieve token data", error.statusText);
+      console.log("Failed to retrieve token data", error ? error.statusText : "");
     });
   };
 
@@ -120,15 +121,15 @@ export default function TimeoutModal() {
       <h2 id="timeout-modal-title">Session Timeout Notice</h2>
       <div id="timeout-modal-description">
           {
-            expiresIn && 
-            expiresIn == 0 && 
+            expiresIn &&
+            expiresIn == 0 &&
             <span className="error">Your current session has expired.</span>
           }
           {
-            expiresIn && 
-            expiresIn != 0 && 
+            expiresIn &&
+            expiresIn != 0 &&
             <span>Your session will expired in approximately {getExpiresInDisplay(expiresIn)}.</span>
-          }   
+          }
           <div className="buttons-container">
             <Button variant="outlined" onClick={handleClose}>OK</Button>
             <Button variant="outlined" onClick={handleLogout}>Log Out</Button>
@@ -137,14 +138,14 @@ export default function TimeoutModal() {
       <TimeoutModal />
     </div>
   );
-  
+
   useEffect(() => {
     initTimeoutTracking();
     return () => {
       clearExpiredIntervalId();
     }
   }, []);
-  
+
   return (
     <div>
       <Modal


### PR DESCRIPTION
Timed out KC session on dashboard would lead to invalid state, forcing user to manually redirect to /logout

Problem was the attempt by the backend to redirect when a validation check failed.  This only works when initiated from the user-agent (browser), not a JavaScript request.
