### PR TITLE
Patient search creation problems

### DIFF
--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -231,10 +231,10 @@ def external_search(resource_type):
         # See if local match already exists
         patient = resource_from_args(resource_type, request.args)
         internal_bundle = internal_patient_search(token, patient)
-        local_fhir_patient = (
-            internal_bundle['entry'][0] if len(internal_bundle['entry'])
-            else None)
-        if len(internal_bundle['entry']) > 1:
+        local_fhir_patient = None
+        if internal_bundle['total'] > 0:
+            local_fhir_patient = internal_bundle['entry'][0]['resource']
+        if internal_bundle['total'] > 1:
             current_app.logger.warning(
                 "found multiple internal matches (%s), return first",
                 patient)

--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -216,6 +216,7 @@ def external_search(resource_type):
 
     """
     token = validate_auth()
+    # Tag any matching results with identifier naming source
     external_search_bundle = add_identifier_to_resource_type(
         bundle=external_request(token, resource_type, request.args),
         resource_type=resource_type,
@@ -224,11 +225,19 @@ def external_search(resource_type):
             'value': 'found'})
 
     if len(external_search_bundle['entry']):
+        # Merge result details with internal resources
         local_fhir_patient = sync_bundle(token, external_search_bundle)
     else:
         # See if local match already exists
         patient = resource_from_args(resource_type, request.args)
-        local_fhir_patient = internal_patient_search(token, patient)
+        internal_bundle = internal_patient_search(token, patient)
+        local_fhir_patient = (
+            internal_bundle['entry'][0] if len(internal_bundle['entry'])
+            else None)
+        if len(internal_bundle['entry']) > 1:
+            current_app.logger.warning(
+                "found multiple internal matches (%s), return first",
+                patient)
 
     # TODO: is there a PHI safe 'id' for the user (in place of email)?
     try:
@@ -238,11 +247,6 @@ def external_search(resource_type):
         user_id = "unknown"
 
     if not local_fhir_patient:
-        # If `sync_bundle` didn't generate or find a patient, a
-        # local didn't previously exist, AND we must not have received
-        # one from the external search (confirm assumption)
-        assert len(external_search_bundle['entry']) == 0
-
         # Add at this time in the local store
         local_fhir_patient = HAPI_POST(token, patient)
         current_app.logger.info(

--- a/patientsearch/models/__init__.py
+++ b/patientsearch/models/__init__.py
@@ -5,6 +5,7 @@ from .sync import (
     HAPI_request,
     add_identifier_to_resource_type,
     external_request,
+    internal_patient_search,
     sync_bundle
 )
 
@@ -15,5 +16,6 @@ __all__ = [
     'HAPI_request',
     'add_identifier_to_resource_type',
     'external_request',
+    'internal_patient_search',
     'sync_bundle',
 ]

--- a/patientsearch/models/sync.py
+++ b/patientsearch/models/sync.py
@@ -160,8 +160,9 @@ def _merge_patient(src_patient, internal_patient, token):
         return HAPI_PUT(token, internal_patient)
 
 
-def sync_patient(token, patient):
-    """Sync single patient resource - insert or update as needed"""
+def internal_patient_search(token, patient):
+    """Look up given patient from "internal" HAPI store, returns bundle"""
+
     # Use same parameters sent to external src looking for existing Patient
     # Note FHIR uses list for 'given', common parameter use defines just one
     search_map = (
@@ -177,8 +178,14 @@ def sync_patient(token, patient):
         if match and isinstance(match, str):
             search_params[queryterm] = compstr + match
 
-    internal_search = HAPI_request(
+    return HAPI_request(
         token=token, resource_type='Patient', params=search_params)
+
+
+def sync_patient(token, patient):
+    """Sync single patient resource - insert or update as needed"""
+
+    internal_search = internal_patient_search(token, patient)
 
     # If found, return the Patient, merging if necessary
     match_count = internal_search['total']


### PR DESCRIPTION
Started with observation of a typo in the birth date will generate a server error.  Found a number of issues including the improper creation of duplicate local patients on a miss.

When no PDMP patient is found, we need to look locally before creation of a new local (HAPI) patient.  (This has resolved most cases but still seeing an occasional duplicate non-PDMP patient creation, which I believe is tied to HAPI caching the search results.)