### PR TITLE
Friendly unauthorized text

### DIFF
--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -60,7 +60,10 @@ def validate_auth():
 
     if not oidc.validate_token(token):
         terminate_session()
-        raise Unauthorized("oidc token invalid")
+        raise Unauthorized(
+            "Your COSRI session timed out. "
+            "Please refresh your browser to enter your user name and password "
+            "to log back in.")
     return token
 
 


### PR DESCRIPTION
update exception text should the front-end refresh fail, as per https://www.pivotaltracker.com/story/show/178579291

NB, this is difficult to reproduce, as generally, the timer on the front-end to frequently call `/validate_token` and redirect if invalid works well.  Only known reproduction:
1. log in to dashboard
2. watch browser network, immediately after a /validate_token call:
3. remove users session from keycloak directly (kc admin -> users -> sessions )
4. refresh tab from step 1
