### PR TITLE
Feature/delete api

### DIFF
--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -261,7 +261,8 @@ def external_search(resource_type):
 
     if not local_fhir_patient:
         # Add at this time in the local store
-        local_fhir_patient = HAPI_request(token=token, method='POST', resource=patient)
+        local_fhir_patient = HAPI_request(
+            token=token, method='POST', resource_type='Patient', resource=patient)
         current_app.logger.info(
             "PDMP search failed; create new patient from search params",
             extra={

--- a/patientsearch/models/__init__.py
+++ b/patientsearch/models/__init__.py
@@ -1,7 +1,5 @@
 from .bearer_auth import BearerAuth
 from .sync import (
-    HAPI_POST,
-    HAPI_PUT,
     HAPI_request,
     add_identifier_to_resource_type,
     external_request,
@@ -11,8 +9,6 @@ from .sync import (
 
 __all__ = [
     'BearerAuth',
-    'HAPI_POST',
-    'HAPI_PUT',
     'HAPI_request',
     'add_identifier_to_resource_type',
     'external_request',


### PR DESCRIPTION
Given all the flavors of HAPI_<method> that had developed, took the opportunity to refactor.  Now a single `HAPI_request` function that takes the necessary options and reduces common code.

@achen2401 you should be able to DELETE a patient by calling the back-end via `DELETE /Patient/<id>`