### PR TITLE
frontend timeout check fixes

### DIFF
--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -259,7 +259,8 @@ export default function PatientListTable(props) {
         setOpenLoadingModal(false);
         return false;
       }
-      if (!results[1] || (results[1] && !results[1].valid)) {
+      if (!results[1] ||
+         (results[1] && (parseInt(results[1].access_expires_in) <= 0 || parseInt(results[1].refresh_expires_in) <= 0))) {
         //invalid token, force logout
         console.log("Logging out...")
         handleLogout();

--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -222,10 +222,11 @@ export default function PatientListTable(props) {
       }
     });
   }
-  const handleLogout = function() {
+  const handleExpiredSession = function() {
     sessionStorage.clear();
     setTimeout(() => {
-      window.location = "/logout";
+      // / is a protected endpoint, the backend will request a new Access Token from Keycloak if able, else prompt a user to log in again
+      window.location = "/";
     }, 0);
   }
   const handleSearch = function (event, rowData) {
@@ -261,9 +262,9 @@ export default function PatientListTable(props) {
       }
       if (!results[1] ||
          (results[1] && (parseInt(results[1].access_expires_in) <= 0 || parseInt(results[1].refresh_expires_in) <= 0))) {
-        //invalid token, force logout
-        console.log("Logging out...")
-        handleLogout();
+        //invalid token, force redirecting
+        console.log("Redirecting...")
+        handleExpiredSession();
         setOpenLoadingModal(true);
         return false;
       }

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -108,7 +108,8 @@ export default function TimeoutModal() {
 
   const reLoad = () => {
     handleClose();
-    location.reload();
+    //To force-request a new Access Token (when one is about to expire, but still valid)
+    window.location =  "/clear_session";
   }
 
   const handleLogout = () => {

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -64,7 +64,7 @@ export default function TimeoutModal() {
           //flag for whether to prompt the user to refresh session, i.e. request another access token
           refresh = tokenAboutToExpire && !refreshTokenOnVentilator ? true: false;
 
-          if (!tokenData["valid"] || expiresIn <= 1) {
+          if (refreshTokenOnVentilator && (!tokenData["valid"] || expiresIn <= 1)) {
             handleLogout();
             return;
           }

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -64,10 +64,15 @@ export default function TimeoutModal() {
           //flag for whether to prompt the user to refresh session, i.e. request another access token
           refresh = tokenAboutToExpire && !refreshTokenOnVentilator ? true: false;
 
-          if (refreshTokenOnVentilator && (!tokenData["valid"] || expiresIn <= 1)) {
-            handleLogout();
+          if (!tokenData["valid"] || expiresIn <= 1) {
+            if (refreshTokenOnVentilator){
+              handleLogout();
+            } else {
+              reLoad();
+            }
             return;
           }
+
           if (tokenAboutToExpire) {
             cleanUpModal();
             if (!open) handleOpen();

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -17,7 +17,7 @@ function getModalStyle() {
 const useStyles = makeStyles((theme) => ({
   paper: {
     position: 'absolute',
-    width: 400,
+    width: 480,
     backgroundColor: theme.palette.background.paper,
     border: `2px solid ${theme.palette.primary.main}`,
     boxShadow: theme.shadows[5],
@@ -27,6 +27,7 @@ const useStyles = makeStyles((theme) => ({
 
 let expiredIntervalId = 0;
 let expiresIn = null;
+let refresh = false;
 
 export default function TimeoutModal() {
   const classes = useStyles();
@@ -37,7 +38,6 @@ export default function TimeoutModal() {
   const clearExpiredIntervalId = () => {
     clearInterval(expiredIntervalId);
   };
-
   const checkSessionValidity = () => {
     /*
      * when the expires in is less than the next track interval, the session will have expired, so just logout user
@@ -53,14 +53,22 @@ export default function TimeoutModal() {
         let tokenData = null;
         try {
           tokenData = JSON.parse(response);
+          let accessTokenExpiresIn = parseFloat(tokenData["access_expires_in"]);
+          let refreshTokenExpiresIn = parseFloat(tokenData["refresh_expires_in"]);
+          let refreshTokenOnVentilator = refreshTokenExpiresIn < accessTokenExpiresIn;
           //in seconds
-          expiresIn = tokenData["expires_in"];
+          //1. check if refresh token will expire before access token first
+          //2. check if access token will expire
+          expiresIn = refreshTokenOnVentilator ? refreshTokenExpiresIn : accessTokenExpiresIn;
+          let tokenAboutToExpire = Math.floor(expiresIn) >= 1 && Math.floor(expiresIn) <= 60;
+          //flag for whether to prompt the user to refresh session, i.e. request another access token
+          refresh = tokenAboutToExpire && !refreshTokenOnVentilator ? true: false;
 
           if (!tokenData["valid"] || expiresIn <= 1) {
             handleLogout();
             return;
           }
-          if (Math.floor(expiresIn) <= 60) {
+          if (tokenAboutToExpire) {
             cleanUpModal();
             if (!open) handleOpen();
           }
@@ -94,8 +102,14 @@ export default function TimeoutModal() {
   };
 
   const handleClose = () => {
+    clearExpiredIntervalId();
     setOpen(false);
   };
+
+  const reLoad = () => {
+    handleClose();
+    location.reload();
+  }
 
   const handleLogout = () => {
     clearExpiredIntervalId();
@@ -132,6 +146,15 @@ export default function TimeoutModal() {
             <span>Your session will expired in approximately {getExpiresInDisplay(expiresIn)}.</span>
           }
           <div className="buttons-container">
+            {/*
+              * access token about to expire so ask user if they want to refresh session
+              * NOTE this button won't show if refresh token is about to expire, i.e. SSO Session Max has been reached
+              */
+            }
+            {
+              refresh &&
+              <Button variant="outlined" onClick={reLoad}>Refresh Session</Button>
+            }
             <Button variant="outlined" onClick={handleClose}>OK</Button>
             <Button variant="outlined" onClick={handleLogout}>Log Out</Button>
           </div>


### PR DESCRIPTION
Fixes for this story: https://www.pivotaltracker.com/story/show/179034819
Changes include:
- Frontend will logout user if validate token api indicates that the refresh token has expired (prior to access token expiration) (timeout modal will appear periodically 60 seconds prior)
-  When access token about to expire and condition applies (refresh token isn't about the expired), will ask user if they want to refresh the session.  If user doesn't take any action, then the frontend  call `/logout` to end session