### PR TITLE
change page size default for patient list to 10

### DIFF
--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -457,6 +457,8 @@ export default function PatientListTable(props) {
                 hideSortIcon={false}
                 options={{
                     paginationTypestepped: "stepped",
+                    pageSize: 10,
+                    pageSizeOptions: [10, 20, 50],
                     toolbar: false,
                     filtering: true,
                     sorting: true,


### PR DESCRIPTION
Per https://www.pivotaltracker.com/story/show/179152310
change default list size to 10 per page for the patient list