### PR TITLE
Do not raise 401 when logged out of /

### DIFF
--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -95,7 +95,6 @@ def current_user_id(token):
 @oidc.require_login
 def main():
     """ Main route, entry point for react. """
-    validate_auth()
     ## issue with path resolution after build
     return send_from_directory(
         #todo: remove templates directory reference; index.html isn't a jinja template


### PR DESCRIPTION
Raising a `401` at `/` does not allow re-login by refreshing. This `401` state can only be cleared by visiting `/logout` manually