### PR TITLE
Use RedisDict for OIDC_CREDENTIAL_STORE

### DIFF
--- a/patientsearch/config.py
+++ b/patientsearch/config.py
@@ -1,7 +1,10 @@
 import json
 import os
+from urllib.parse import urlparse
 
 import redis
+from redis_dict import RedisDict
+
 
 def decode_json_config(potential_json_string):
     """Detect if given string is JSON file, or JSON string"""
@@ -19,6 +22,12 @@ REDIS_URL = os.environ.get('REDIS_URL')
 if REDIS_URL:
     SESSION_TYPE = "redis"
     SESSION_REDIS = redis.from_url(REDIS_URL)
+    parts = urlparse(REDIS_URL)
+    OIDC_CREDENTIALS_STORE = RedisDict(
+        namespace='oidc_store',
+        host=parts.hostname,
+        port=parts.port,
+        db=int(parts.path[1:]))
 
 STATIC_DIR = os.getenv("STATIC_DIR")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ markupsafe==1.1.1         # via jinja2
 python-json-logger==0.1.11
 pyjwt==1.7.1              # via flask-jwt-extended
 redis==3.5.3
+redis-dict==1.5.2         # via patientsearch (setup.py)
 requests==2.24.0          # via patientsearch (setup.py)
 six==1.15.0               # via flask-jwt-extended
 urllib3==1.25.9           # via requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     gunicorn
     requests
     redis
+    redis-dict
     jmespath
     python-json-logger
 


### PR DESCRIPTION
Add RedisDict and configure as the flask-oidc OIDC_CREDENTIAL_STORE for reliable session management.

Verified it functions via `redit-cli`:

```
127.0.0.1:6379[3]> keys *
1) "oidc_store:9cc1d639-0a1d-4c9f-ada2-1b9fa133cf7f"
2) "session:3282dfbd-a4e6-4d23-9f5f-e6318dc34b55"
```