### PR TITLE
Return JSON on error for JSON views.  Enhance audit logging.

### DIFF
--- a/patientsearch/__init__.py
+++ b/patientsearch/__init__.py
@@ -89,4 +89,4 @@ def configure_logging(app):
     app.logger.addHandler(log_server_handler)
     app.logger.debug(
         "cosri patientsearch logging initialized",
-        extra={'bonus': 'data', 'tags': ['testing', 'logging']})
+        extra={'tags': ['testing', 'logging']})

--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -83,7 +83,7 @@ def current_user_id(token):
         username = oidc.user_getfield('preferred_username')
     except Exception:
         # mystery how token was valid at entry and now inaccessible
-        namename = "unknown"
+        username = "unknown"
     try:
         DEA = oidc.user_getfield('DEA')
     except Exception:

--- a/patientsearch/jsonify_abort.py
+++ b/patientsearch/jsonify_abort.py
@@ -1,9 +1,8 @@
 """Utility function to bring together flask `abort` and `jsonify`"""
 from flask import abort, jsonify, make_response
 
-def jsonify_abort(**kwargs):
+def jsonify_abort(status_code, **kwargs):
     """Takes any number of args, like jsonify, but raises like abort with correct content_type heading"""
-    status_code = kwargs.pop('status_code', 500)
     response = make_response(jsonify(kwargs))
     response.status_code = status_code
     abort(response)

--- a/patientsearch/jsonify_abort.py
+++ b/patientsearch/jsonify_abort.py
@@ -1,0 +1,9 @@
+"""Utility function to bring together flask `abort` and `jsonify`"""
+from flask import abort, jsonify, make_response
+
+def jsonify_abort(**kwargs):
+    """Takes any number of args, like jsonify, but raises like abort with correct content_type heading"""
+    status_code = kwargs.pop('status_code', 500)
+    response = make_response(jsonify(kwargs))
+    response.status_code = status_code
+    abort(response)


### PR DESCRIPTION
When aborting from JSON views, use new `jsonify_abort()` to raise with correct headers intact.
Clean up the audit logs with consistent extra info