### PR TITLE
add system type banner for non-production isntances

### DIFF
--- a/patientsearch/src/js/App.js
+++ b/patientsearch/src/js/App.js
@@ -4,6 +4,7 @@ import { ThemeProvider } from '@material-ui/styles';
 import Header from './components/Header';
 import PatientListTable from './components/PatientListTable';
 import TimeoutModal from './components/TimeoutModal.js';
+import SystemBanner from './components/SystemBanner';
 import Version from './components/Version';
 import theme from './context/theme';
 import '../styles/app.scss';
@@ -14,6 +15,7 @@ export default class App extends Component {
       <React.Fragment>
         <ThemeProvider theme={theme}>
           <CssBaseline />
+          <SystemBanner />
           <Header />
           <PatientListTable />
           <TimeoutModal />

--- a/patientsearch/src/js/components/SystemBanner.js
+++ b/patientsearch/src/js/components/SystemBanner.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { makeStyles} from '@material-ui/core/styles';
+import {sendRequest} from './Utility';
+import theme from '../context/theme';
+
+const useStyles = makeStyles({
+    container: {
+        textAlign: "center",
+        position: "fixed",
+        top: 0,
+        width: "100%",
+        zIndex: 9999,
+        backgroundColor: theme.palette.primary.warningLight
+    }
+});
+
+export default function SiteLogo() {
+    const classes = useStyles();
+    const [setting, setSetting] = React.useState({});
+    const [systemType, setSystemType] = React.useState("");
+    const [initialized, setInitialized] = React.useState(false);
+    const SYSTEM_TYPE_STRING = "SYSTEM_TYPE";
+    React.useEffect(() => {
+        /*
+         * retrieve setting information
+         */
+        sendRequest("./settings").then(response => {
+            let data = null;
+            try {
+                data = JSON.parse(response);
+            } catch(e) {
+                console.log("error parsing data ", e);
+            }
+            setSetting(data);
+            setSystemType(getSystemType());
+            setInitialized(true);
+        }, error => {
+            console.log("Failed to retrieve data", error.statusText);
+            setInitialized(true);
+        });
+    }, [initialized]);
+    function getSystemType() {
+        if (!Object.keys(setting)) return "";
+        return setting[SYSTEM_TYPE_STRING];
+    }
+    function isNonProduction() {
+        return systemType && String(systemType.toLowerCase()) !== "production";
+    }
+    return (
+        /* display system type for non-production instances */
+        <div className={classes.container}>{isNonProduction() && <span>{systemType} version - not for clinical use</span>}</div>
+    );
+}

--- a/patientsearch/src/js/components/SystemBanner.js
+++ b/patientsearch/src/js/components/SystemBanner.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles({
     }
 });
 
-export default function SiteLogo() {
+export default function SystemBanner() {
     const classes = useStyles();
     const [setting, setSetting] = React.useState({});
     const [systemType, setSystemType] = React.useState("");

--- a/patientsearch/src/js/context/theme.js
+++ b/patientsearch/src/js/context/theme.js
@@ -13,7 +13,8 @@ const theme = createMuiTheme({
         dark: cyan[900],
         disabled: "#d2dad2",
         success: "green",
-        warning: "#bb812a"
+        warning: "#bb812a",
+        warningLight: "rgba(250,194,25,.7)"
     },
     secondary: {
       main: "#3c3535",


### PR DESCRIPTION
part of https://www.pivotaltracker.com/story/show/179458572
display system type banner for instances that aren't production
Change include:
Banner will display based on the config variable, `SYSTEM_TYPE`