### PR TITLE
Add resource ID to end of PUT requests by passing resource_id

### DIFF
--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -299,7 +299,10 @@ def external_search(resource_type):
 
     if external_match_count:
         # Merge result details with internal resources
-        local_fhir_patient = sync_bundle(token, external_search_bundle)
+        try:
+            local_fhir_patient = sync_bundle(token, external_search_bundle)
+        except ValueError:
+            return jsonify_abort(message="Error in local sync", status_code=400)
         if local_fhir_patient:
             extra['patient']['subject.id'] = local_fhir_patient['id']
     else:

--- a/patientsearch/models/sync.py
+++ b/patientsearch/models/sync.py
@@ -7,7 +7,6 @@ from jmespath import search as json_search
 import requests
 
 from patientsearch.models.bearer_auth import BearerAuth
-from patientsearch.jsonify_abort import jsonify_abort
 from patientsearch.logserverhandler import audit_entry
 
 
@@ -78,7 +77,10 @@ def HAPI_request(
     try:
         resp.raise_for_status()
     except requests.exceptions.HTTPError as err:
-        return jsonify_abort(message=err, status_code=err.response.status_code)
+        audit_entry(
+                f"Failed HAPI call ({method} {resource_type} {resource_id} {resource} {params}): {err}",
+                extra={'tags': ['Internal', 'Exception', resource_type]})
+        raise ValueError(err)
     return resp.json()
 
 

--- a/patientsearch/models/sync.py
+++ b/patientsearch/models/sync.py
@@ -169,7 +169,7 @@ def _merge_patient(src_patient, internal_patient, token):
     else:
         internal_patient['identifier'] = src_patient['identifier']
         return HAPI_request(
-            token=token, method='PUT', resource_type='Patient', resource=internal_patient)
+            token=token, method='PUT', resource_type='Patient', resource=internal_patient, resource_id=internal_patient["id"])
 
 
 def internal_patient_search(token, patient):


### PR DESCRIPTION
FHIR HTTP PUT requires a resource ID to update at the end. When PUTing resources, retrieve the ID to PUT, from inside the given resource

[See 
](https://www.hl7.org/fhir/http.html#update)
