### PR TITLE
Fix errors found on delete

### DIFF
--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -206,7 +206,7 @@ def delete_resource_by_id(resource_type, resource_id):
     extra = {'tags': ['patient', 'delete'], 'user': current_user_id(token)}
     if resource_type == 'Patient':
         extra['patient'] = {'subject.id': resource_id}
-    audit_entry("DELETE %s/%s", resource_type, resource_id, extra=extra)
+    audit_entry(f"DELETE {resource_type}/{resource_id}", extra=extra)
 
     try:
         return jsonify(HAPI_request(
@@ -316,7 +316,7 @@ def external_search(resource_type):
         if internal_bundle['total'] > 0:
             local_fhir_patient = internal_bundle['entry'][0]['resource']
         if internal_bundle['total'] > 1:
-            audit_entry("found multiple internal matches (%s), return first", patient, extra=extra, level='warn')
+            audit_entry(f"found multiple internal matches ({patient}), return first", extra=extra, level='warn')
 
     if not local_fhir_patient:
         # Add at this time in the local store

--- a/patientsearch/models/sync.py
+++ b/patientsearch/models/sync.py
@@ -55,7 +55,8 @@ def HAPI_request(
         # Disable caching until we find the need and safe use cases
         headers = {'Cache-Control': 'no-cache'}
         # TODO handle paging.  Workaround with increased page size
-        params['_count'] = 1000
+        if params is not None:
+            params['_count'] = 1000
         try:
             resp = requests.get(
                 url, auth=BearerAuth(token), headers=headers, params=params)


### PR DESCRIPTION
Lookup for a single patient doesn't include params, thus setting `_count` doesn't apply.
Old school string formatting on audit_entry() fails, update to format message before call. 