### PR TITLE
Unauthorized Workaround

### DIFF
--- a/patientsearch/extensions.py
+++ b/patientsearch/extensions.py
@@ -1,3 +1,13 @@
 from flask_oidc import OpenIDConnect
+from flask import redirect, current_app
 
-oidc = OpenIDConnect()
+
+class OpenIDConnectRedirect(OpenIDConnect):
+    """Extend OIDC class to redirect back to root on error"""
+    def _oidc_error(self, message=None, code=None):
+        message = f": {message}" if message is not None else ""
+        current_app.logger.error(f"Error{message}; redirecting to /")
+        return redirect('/')
+
+
+oidc = OpenIDConnectRedirect()


### PR DESCRIPTION
Override flask_oidc error callback to redirect to /

When any of the Keycloak login querystring parameters are invalid (or stale), flask_oidc returns an error page without a way forward. Override the error callback to redirect to `/` instead, to start another login attempt.
