### PR TITLE
Feature/info page

### DIFF
--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -402,3 +402,15 @@ def logout():
     ))
     resp.set_cookie('oidc_id_token', '', expires=0)
     return resp
+
+@api_blueprint.route('/info', methods=["GET"])
+def info():
+    """ entry point for pre-authenticated access """
+    return send_from_directory(
+        safe_join(
+            current_app.config.get("STATIC_DIR") or current_app.static_folder,
+            'templates'
+        ),
+        'info.html',
+        cache_timeout=-1
+    )

--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -403,14 +403,15 @@ def logout():
     resp.set_cookie('oidc_id_token', '', expires=0)
     return resp
 
-@api_blueprint.route('/info', methods=["GET"])
-def info():
+@api_blueprint.route('/home', methods=["GET"])
+def home():
     """ entry point for pre-authenticated access """
+    """ TODO if authenticated redirect to / ? """
     return send_from_directory(
         safe_join(
             current_app.config.get("STATIC_DIR") or current_app.static_folder,
             'templates'
         ),
-        'info.html',
+        'home.html',
         cache_timeout=-1
     )

--- a/patientsearch/src/js/Landing.js
+++ b/patientsearch/src/js/Landing.js
@@ -1,0 +1,18 @@
+import React from "react";
+import { render } from 'react-dom';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import { ThemeProvider } from '@material-ui/styles';
+import Header from './components/Header';
+import Info from './components/Info';
+import theme from './context/theme';
+import '../styles/app.scss';
+
+// entry point
+render(<React.Fragment>
+    <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Header />
+        <Info />
+    </ThemeProvider>
+</React.Fragment>,
+document.getElementById("content"));

--- a/patientsearch/src/js/Landing.js
+++ b/patientsearch/src/js/Landing.js
@@ -8,7 +8,7 @@ import Version from './components/Version';
 import theme from './context/theme';
 import '../styles/app.scss';
 
-// entry point
+// entry point for pre-authenticated access
 render(<React.Fragment>
     <ThemeProvider theme={theme}>
         <CssBaseline />

--- a/patientsearch/src/js/Landing.js
+++ b/patientsearch/src/js/Landing.js
@@ -4,6 +4,7 @@ import CssBaseline from '@material-ui/core/CssBaseline';
 import { ThemeProvider } from '@material-ui/styles';
 import Header from './components/Header';
 import Info from './components/Info';
+import Version from './components/Version';
 import theme from './context/theme';
 import '../styles/app.scss';
 
@@ -11,8 +12,11 @@ import '../styles/app.scss';
 render(<React.Fragment>
     <ThemeProvider theme={theme}>
         <CssBaseline />
-        <Header />
-        <Info />
+        <section className="landing">
+            <Header />
+            <Info />
+            <Version className="version-container" />
+        </section>
     </ThemeProvider>
 </React.Fragment>,
 document.getElementById("content"));

--- a/patientsearch/src/js/components/Info.js
+++ b/patientsearch/src/js/components/Info.js
@@ -13,7 +13,10 @@ const useStyles = makeStyles({
         marginTop: theme.spacing(24),
         display: "flex",
         flexDirection: "column",
-        alignItems: "center"
+        alignItems: "center",
+        minHeight: "100",
+        flex: "1 0 auto",
+        paddingBottom: theme.spacing(4)
     },
     button: {
         width: "240px",
@@ -25,7 +28,7 @@ const useStyles = makeStyles({
         maxWidth: "640px"
     },
     title: {
-        fontSize: "1.3rem",
+        fontSize: "1.25rem",
         lineHeight: "1.5"
     }
 });
@@ -36,7 +39,8 @@ export default function Info() {
     const [siteID, setSiteID] = React.useState("");
     const [initialized, setInitialized] = React.useState(false);
     const SYSTEM_TYPE_STRING = "SYSTEM_TYPE";
-    const SITE_INFO_STRING = "SITE_INFO";
+    //config name for site login HTML string
+    const SITE_INFO_STRING = "SITE_LOGIN_INFO";
     const SITE_ID_STRING = "SITE_ID";
     const siteNameMappings = {
         "FCK": "FamilyCare of Kent",
@@ -64,7 +68,7 @@ export default function Info() {
     /*
      * return info content specific for the site
      */
-    function getSiteInfo() {
+    function getSiteLoginInfo() {
         if (!Object.keys(setting)) return "";
         return setting[SITE_INFO_STRING];
     }
@@ -102,7 +106,7 @@ export default function Info() {
     }
     function getMessage() {
         //configurable display text for a specific site
-        if (getSiteInfo()) return getSiteInfo();
+        if (getSiteLoginInfo()) return getSiteLoginInfo();
         if (!siteID) return `This is a ${getSystemType()} system.  Not for clinical use.`;
         if (siteID === "demo") {
             return "Public Demonstration version of COSRI. <br/>Log in with username:test and password:test.";
@@ -116,7 +120,6 @@ export default function Info() {
     return (
         <div className={classes.container}>
             {siteID && <img src={"/static/"+siteID+"/img/logo.png"} onLoad={handleImageLoaded} onError={handleImageLoadError}></img>}
-            <br/>
             <Button color="primary" href="/" align="center" variant="outlined" size="large" className={classes.button}>Click here to log in</Button>
             <div className={classes.info}>
                 <Typography component="h4" variant="h5" color="inherit" align="center" className={classes.title}>

--- a/patientsearch/src/js/components/Info.js
+++ b/patientsearch/src/js/components/Info.js
@@ -34,10 +34,10 @@ export default function Info() {
     const classes = useStyles();
     const [setting, setSetting] = React.useState({});
     const [siteID, setSiteID] = React.useState("");
-    const [systemType, setSystemType] = React.useState("");
     const [initialized, setInitialized] = React.useState(false);
     const SYSTEM_TYPE_STRING = "SYSTEM_TYPE";
     const SITE_ID_STRING = "SITE_ID";
+    //site name should probably come from config?
     const siteNameMappings = {
         "FCK": "FamilyCare of Kent",
         "SFH": "Skagit Family Health"
@@ -102,7 +102,6 @@ export default function Info() {
         if (siteName) {
             return `This system is only for use by clinical staff of ${siteName}.`;
         }
-        //TODO is there a config var for site name?
         return "This system is only for use by clinical staff.";
     }
     return (

--- a/patientsearch/src/js/components/Info.js
+++ b/patientsearch/src/js/components/Info.js
@@ -105,7 +105,7 @@ export default function Info() {
         }
     }
     function getMessage() {
-        //configurable display text for a specific site
+        //configurable display HTML string for a specific site, IF available, will use it.
         if (getSiteLoginInfo()) return getSiteLoginInfo();
         if (!siteID) return `This is a ${getSystemType()} system.  Not for clinical use.`;
         if (siteID === "demo") {

--- a/patientsearch/src/js/components/Info.js
+++ b/patientsearch/src/js/components/Info.js
@@ -1,0 +1,120 @@
+import React from 'react';
+import { makeStyles} from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+import {imageOK, sendRequest} from './Utility';
+import theme from '../context/theme';
+
+const useStyles = makeStyles({
+    container: {
+        textAlign: "center",
+        marginLeft: theme.spacing(2),
+        marginRight: theme.spacing(2),
+        marginTop: theme.spacing(24),
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center"
+    },
+    button: {
+        width: "240px",
+        borderWidth: "2px",
+        marginTop: theme.spacing(3)
+    },
+    info: {
+        marginTop: theme.spacing(3),
+        maxWidth: "640px"
+    },
+    title: {
+        fontSize: "1.3rem",
+        lineHeight: "1.5"
+    }
+});
+
+export default function Info() {
+    const classes = useStyles();
+    const [setting, setSetting] = React.useState({});
+    const [siteID, setSiteID] = React.useState("");
+    const [systemType, setSystemType] = React.useState("");
+    const [initialized, setInitialized] = React.useState(false);
+    const SYSTEM_TYPE_STRING = "SYSTEM_TYPE";
+    const SITE_ID_STRING = "SITE_ID";
+    const siteNameMappings = {
+        "FCK": "FamilyCare of Kent",
+        "SFH": "Skagit Family Health"
+    }
+    React.useEffect(() => {
+        /*
+         * retrieve setting information
+         */
+        sendRequest("./settings").then(response => {
+            let data = null;
+            try {
+                data = JSON.parse(response);
+            } catch(e) {
+                console.log("error parsing data ", e);
+            }
+            setSetting(data);
+            setSiteID(getSiteId());
+            setInitialized(true);
+        }, error => {
+            console.log("Failed to retrieve data", error.statusText);
+            setInitialized(true);
+        });
+    }, [initialized]);
+    function getSiteId() {
+        if (!Object.keys(setting)) return "";
+        return setting[SITE_ID_STRING];
+    }
+    function getSystemType() {
+        if (!Object.keys(setting)) return "test";
+        return setting[SYSTEM_TYPE_STRING];
+    }
+    function handleImageLoaded(e) {
+        if (!e.target) {
+          return false;
+        }
+        let imageLoaded = imageOK(e.target);
+        if (!imageLoaded) {
+          e.target.setAttribute("disabled", true);
+          return;
+        }
+        let defaultLogoImage = document.querySelector(".default-logo");
+        if (defaultLogoImage) {
+          defaultLogoImage.setAttribute("disabled", true);
+        }
+    }
+    function handleImageLoadError(e) {
+        if (!e.target) {
+          return false;
+        }
+        let imageLoaded = imageOK(e.target);
+        if (!imageLoaded) {
+          e.target.setAttribute("disabled", true);
+          return;
+        }
+    }
+    function getMessage() {
+        if (!siteID) return `This is a ${getSystemType()} system.  Not for clinical use.`;
+        if (siteID === "demo") {
+            return "Public Demonstration version of COSRI. Log in with username:test and password:test.";
+        }
+        let siteName = siteNameMappings[siteID];
+        if (siteName) {
+            return `This system is only for use by clinical staff of ${siteName}.`;
+        }
+        //TODO is there a config var for site name?
+        return "This system is only for use by clinical staff.";
+    }
+    return (
+        <div className={classes.container}>
+            {siteID && <img src={"/static/"+siteID+"/img/logo.png"} onLoad={handleImageLoaded} onError={handleImageLoadError}></img>}
+            <br/>
+            <Button color="primary" href="/" align="center" variant="outlined" size="large" className={classes.button}>Click here to log in</Button>
+            <div className={classes.info}>
+                <Typography component="h4" variant="h5" color="inherit" align="center" className={classes.title}>
+                    {getMessage()}
+                </Typography>
+            </div>
+        </div>
+    );
+}

--- a/patientsearch/src/js/components/Info.js
+++ b/patientsearch/src/js/components/Info.js
@@ -36,8 +36,8 @@ export default function Info() {
     const [siteID, setSiteID] = React.useState("");
     const [initialized, setInitialized] = React.useState(false);
     const SYSTEM_TYPE_STRING = "SYSTEM_TYPE";
+    const SITE_INFO_STRING = "SITE_INFO";
     const SITE_ID_STRING = "SITE_ID";
-    //site name should probably come from config?
     const siteNameMappings = {
         "FCK": "FamilyCare of Kent",
         "SFH": "Skagit Family Health"
@@ -61,6 +61,13 @@ export default function Info() {
             setInitialized(true);
         });
     }, [initialized]);
+    /*
+     * return info content specific for the site
+     */
+    function getSiteInfo() {
+        if (!Object.keys(setting)) return "";
+        return setting[SITE_INFO_STRING];
+    }
     function getSiteId() {
         if (!Object.keys(setting)) return "";
         return setting[SITE_ID_STRING];
@@ -94,9 +101,11 @@ export default function Info() {
         }
     }
     function getMessage() {
+        //configurable display text for a specific site
+        if (getSiteInfo()) return getSiteInfo();
         if (!siteID) return `This is a ${getSystemType()} system.  Not for clinical use.`;
         if (siteID === "demo") {
-            return "Public Demonstration version of COSRI. Log in with username:test and password:test.";
+            return "Public Demonstration version of COSRI. <br/>Log in with username:test and password:test.";
         }
         let siteName = siteNameMappings[siteID];
         if (siteName) {
@@ -111,7 +120,7 @@ export default function Info() {
             <Button color="primary" href="/" align="center" variant="outlined" size="large" className={classes.button}>Click here to log in</Button>
             <div className={classes.info}>
                 <Typography component="h4" variant="h5" color="inherit" align="center" className={classes.title}>
-                    {getMessage()}
+                    <div dangerouslySetInnerHTML={{ __html: getMessage()}}></div>
                 </Typography>
             </div>
         </div>

--- a/patientsearch/src/js/components/Version.js
+++ b/patientsearch/src/js/components/Version.js
@@ -8,7 +8,7 @@ const useStyles = makeStyles({
         margin: theme.spacing(2, 3, 2),
         color: theme.palette.muted.main,
         [theme.breakpoints.up('md')]: {
-            maxWidth: "960px",
+            maxWidth: "1080px",
             marginLeft: "auto",
             marginRight: "auto",
             paddingLeft: theme.spacing(3),
@@ -17,7 +17,7 @@ const useStyles = makeStyles({
     }
 });
 
-export default function Version() {
+export default function Version(props) {
     const classes = useStyles();
     const [setting, setSetting] = React.useState({});
     const [version, setVersion] = React.useState("");
@@ -42,6 +42,6 @@ export default function Version() {
         return setting[VERSION_STRING];
     }
     return (
-        <div className={classes.container}>{version && <div className="version-container">Version Number: {version}</div>}</div>
+        <div className={props.className ? props.className : classes.container}>{version && <div>Version Number: {version}</div>}</div>
     );
 }

--- a/patientsearch/src/styles/app.scss
+++ b/patientsearch/src/styles/app.scss
@@ -9,6 +9,21 @@ $table-header-bg-color: rgb(224, 242, 241);
 html {
   scroll-behavior: smooth;
 }
+.landing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+}
+.version-container {
+  flex-shrink: 0;
+  height: 32px;
+  margin-top: -32px;
+  text-align: right;
+  width: 100%;
+  padding-left: 24px;
+  padding-right: 24px;
+}
 .logout-container {
   margin-top: 196px;
   display: flex;
@@ -182,15 +197,6 @@ button.disabled:focus,
   button {
     padding: 4px 16px;
     min-width: 120px;
-  }
-}
-
-.version-container {
-  opacity: 0;
-}
-.ready {
-  .version-container {
-    opacity: 1;
   }
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ module.exports = function(_env, argv) {
   return {
     entry:  {
       "index" : ['whatwg-fetch', path.join(__dirname, '/patientsearch/src/js/Entry.js')],
+      "info": path.join(__dirname, '/patientsearch/src/js/Landing.js'),
       "logout": path.join(__dirname, '/patientsearch/src/js/Logout.js')
     },
     watchOptions: {
@@ -89,6 +90,13 @@ module.exports = function(_env, argv) {
         filename: path.join(__dirname, `${templateDirectory}/index.html`),
         favicon: faviconFilePath,
         chunks: ['index']
+      }),
+      new HtmlWebpackPlugin({
+        title: appTitle,
+        template: templateFilePath,
+        filename: path.join(__dirname, `${templateDirectory}/info.html`),
+        favicon: faviconFilePath,
+        chunks: ['info']
       }),
       new HtmlWebpackPlugin({
         title: appTitle,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,7 +94,7 @@ module.exports = function(_env, argv) {
       new HtmlWebpackPlugin({
         title: appTitle,
         template: templateFilePath,
-        filename: path.join(__dirname, `${templateDirectory}/info.html`),
+        filename: path.join(__dirname, `${templateDirectory}/home.html`),
         favicon: faviconFilePath,
         chunks: ['info']
       }),


### PR DESCRIPTION
Address https://www.pivotaltracker.com/story/show/179807563
landing page prior to authentication
front-end will look for the config variable `SITE_LOGIN_INFO` containing the site-specific login info HTML string to populate content

TODO and probably addressed in a different story as this set of changes is UI specific:
make the view accessible only pre-authentication, i.e. if user is authenticated, should re-direct to patient list view

