### PR TITLE
Try out `git` vs. `https` protocol for pulling tagged versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ charset-normalizer==2.0.6  # via requests
 click==8.0.1              # via flask
 flask-jwt-extended==3.24.1  # via patientsearch (setup.py)
 # pin to last hash of master, to remove requirement of freestanding JSON config file
-git+https://github.com/puiterwijk/flask-oidc.git@7f16e27#egg=flask-oidc
+git+git://github.com/puiterwijk/flask-oidc.git@7f16e27#egg=flask-oidc
 flask==2.0.1              # via flask-jwt-extended, patientsearch (setup.py)
 flask-session==0.3.2      # via patientsearch (setup.py)
 gunicorn==20.0.4          # via patientsearch (setup.py)


### PR DESCRIPTION
Builds including `requirements.txt` entries with the 'https' protocol from GitHub started failing:
```
The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

Switching to the `git` protocol looks to function.

Digging deeper, it looks like the dependency on `flask-oidc` itself, includes a sub-module, [which itself uses the `git` protocol to pull. ](https://github.com/puiterwijk/flask-oidc/blob/master/.gitmodules) Perhaps this fix worked as the protocols now match.  Not clear.


  