### PR TITLE
hide more menu based on config

### DIFF
--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -626,6 +626,15 @@ export default function PatientListTable(props) {
     }, 200);
     handleMenuClose();
   }
+  const MORE_MENU_KEY = "MORE_MENU";
+  const shouldHideMoreMenu = () => {
+    //TODO fix this if we have more menu items added, right now just hide the ... menu link if no urine drug screen is specfied as a menu item, since that means no menu item to show
+    return shouldHideUrineScreenMenu() || (Object.keys(appSettings).length && (!appSettings[MORE_MENU_KEY] || appSettings[MORE_MENU_KEY].length === 0));
+  }
+  const shouldHideUrineScreenMenu = () => {
+    let arrMenu = appSettings[MORE_MENU_KEY] ? appSettings[MORE_MENU_KEY]: [];
+    return arrMenu.indexOf("UDS") === -1;
+  }
 
   const getPatientList = (query) => {
     let sortField = query.orderBy && query.orderBy.field? FieldNameMaps[query.orderBy.field] : "_lastUpdated";
@@ -784,7 +793,7 @@ export default function PatientListTable(props) {
                     tooltip: 'Launch COSRI application for the user'
                   },
                   {
-                    icon: () => <MoreHorizIcon color="primary"></MoreHorizIcon>,
+                    icon: () => <MoreHorizIcon color="primary" className={`more-icon ${shouldHideMoreMenu()?'ghost': ''}`}></MoreHorizIcon>,
                     onClick: (event, rowData) => handleMenuClick(event, rowData),
                     tooltip: "More"
                   }
@@ -951,7 +960,7 @@ export default function PatientListTable(props) {
               <Typography variant="subtitle2" className={classes.menuTitleText}>Select</Typography>
               <Button size="small" onClick={handleMenuClose} className={classes.menuCloseButton}>X</Button>
             </div>
-            <MenuItem onClick={(event) => handleMenuSelect(event)} dense>
+            <MenuItem onClick={(event) => handleMenuSelect(event)} className={`${shouldHideUrineScreenMenu()?'ghost':''}`}dense>
               <ListItemIcon className={classes.menuIcon} datatopic="urine screen">
                 <AddCircleOutlineIcon fontSize="small"/>
               </ListItemIcon>

--- a/patientsearch/src/styles/app.scss
+++ b/patientsearch/src/styles/app.scss
@@ -10,6 +10,13 @@ $table-header-bg-color: rgb(224, 242, 241);
 html {
   scroll-behavior: smooth;
 }
+.ghost {
+  display: none;
+  z-index: -1;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}
 .landing {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Changes include:
hide  More menu if a env var, `MORE_MENU` is not present, or is it is an empty array, or it does not contain 'UDS' 
Example:
will show menu if
`MORE_MENU='["UDS"]'`
will not show menu if 
`MORE_MENU='[]'`