### PR TITLE
Add config for UDS_LAB_TYPES.  Expects nested data, load as JSON string.

### DIFF
--- a/patientsearch/config.py
+++ b/patientsearch/config.py
@@ -70,3 +70,4 @@ else:
 OIDC_ID_TOKEN_COOKIE_SECURE = False
 OIDC_REQUIRE_VERIFIED_EMAIL = False
 OIDC_SCOPES = ['email', 'openid', 'roles']
+UDS_LAB_TYPES = json.loads(os.getenv("UDS_LAB_TYPES", '[]'))


### PR DESCRIPTION
Enable site specific UDS labs, used in the drop down for adding new ServiceRecords and the ```system|code``` used to look up existing.

Site specific config values, for patient-search (aka dashboard):

Skagit:
```
UDS_LAB_TYPES='[{"text": "Pain Management Profile (13 Drugs), Urine (PMP-13)", "code": "763824", "display": "12+Oxycodone+Crt-Unbund", "system": "https://www.labcorp.com/tests"}, {"text": "Pain Management Screening Profile (11 Drugs), Urine (PMP-11S)", "code": "733727", "display": "10+Oxycodone+Crt-Scr", "system": "https://www.labcorp.com/tests"}]'
```

Kent:
```
UDS_LAB_TYPES='[{"text": "Drug Monitoring, Panel 6 with Confirmation, Urine", "code": "39428", "display": "Prescription Drug Monitoring,Pain Management", "system": "https://testdirectory.questdiagnostics.com/test"}]'
```