### PR TITLE
Bugfix/pagination infinite loop

### DIFF
--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -667,6 +667,10 @@ export default function PatientListTable(props) {
           apiURL = nextPageURL;
         } else if ((pageNumber < prevPageNumber) && prevPageURL) {
           apiURL = prevPageURL;
+        } else {
+          if (nextPageURL) {
+            apiURL = nextPageURL;
+          }
         }
     }
     if (searchString) apiURL += `&${searchString}`;

--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -672,6 +672,9 @@ export default function PatientListTable(props) {
           if (nextPageURL) {
             apiURL = nextPageURL;
           }
+          if (prevPageURL) {
+            apiURL = prevPageURL;
+          }
         }
     }
     if (searchString) apiURL += `&${searchString}`;
@@ -718,6 +721,7 @@ export default function PatientListTable(props) {
             setDisableNextButton(!hasNextLink);
             setDisablePrevButton(pageNumber === 0);
             setTotalCount(response.total);
+            console.log("in resolve nextPageURL ", nextPageURL, " prevPageURL ", prevPageURL);
             resolve({
               data: responseData,
               page: currentPage,

--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -660,6 +660,7 @@ export default function PatientListTable(props) {
       setInitialized(true);
     };
     let apiURL = `/fhir/Patient?_include=Patient:link&_total=accurate&_count=${pageSize}&_getpagesoffset=0`;
+    console.log("pageNumber ? ", pageNumber, " prevPageNumber ", prevPageNumber, " nextPageURL ", nextPageURL)
     if (searchString) {
       resetPaging();
     } else {


### PR DESCRIPTION
address https://www.pivotaltracker.com/story/show/180464776
Fix pagination issue encountered when navigating to next page for a total data count is less than 20 and a page size of 10

Changes include:
remove duplicate state variable, i.e.pageSize that caused infinite loop when they were being set
reset page number, next page url and previous page url when rows per page size is reset