### PR TITLE
bugfix - fix incidental change of logic

### DIFF
--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -423,10 +423,8 @@ export default function PatientListTable(props) {
   }
 
   function containEmptyFilter(filters) {
-    if (!filters) return true;
-    return filters.filter(item => {
-      return !item.value;
-    }).length > 0;
+    if (!filters || !filters.length) return true;
+    return filters.filter(item => item.value !== "" && item.value !== null).length === 0;
   }
 
   function setToolbarActionButtonVis(filters) {
@@ -458,7 +456,7 @@ export default function PatientListTable(props) {
       if (filters && filters.length) {
         setCurrentFilters(filters);
         resetPaging();
-        if (!containEmptyFilter(filters)) {
+        if (containEmptyFilter(filters)) {
           handleRefresh();
           return filters;
         }


### PR DESCRIPTION
This [commit](https://github.com/uwcirg/cosri-patientsearch/commit/a4d5fa3b2bbd25914f79048852071a2ccd51c2a6#diff-30f40d849e54bd8a7fece391c80406eb4c8a213d75b48afc16170c35090c6da3R461)  from last PR screwed up new patient addition.  Was originally intended to clean up duplicate code , `hasFilters` && `containEmptyFilter` which serve similar purpose but actually opposite meaning