### PR TITLE
address dotdotdot menu visibility issue related to settings

### DIFF
--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -665,8 +665,8 @@ export default function PatientListTable(props) {
         return;
       }
       setAppSettings(data);
-    });
-  }, []);
+    }, true); //no caching
+  }, [!patientListInitialized()]); //retrieval of settings should occur prior to patient list being rendered/initialized
 
   return (
       <React.Fragment>


### PR DESCRIPTION
address https://www.pivotaltracker.com/story/show/180711107
the `...` menu doesn't appear on each row when list is loaded

Change include:
- ensure the ajax request to get settings is not cached
- ensure the request to retrieve setting is complete prior to rendering of patient list