### PR TITLE
address semgrep report

### DIFF
--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -52,7 +52,7 @@ def terminate_session():
             "client_secret": oidc.client_secrets["client_secret"],
             "refresh_token": oidc.get_refresh_token(),
         }
-        requests.post(logout_uri, auth=BearerAuth(token), data=data)
+        requests.post(logout_uri, auth=BearerAuth(token), data=data, timeout=30)
 
     oidc.logout()  # clears local cookie only
     session.clear()

--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -541,7 +541,9 @@ def logout():
             cache_timeout=-1,
         )
     )
-    resp.set_cookie("oidc_id_token", "", expires=0, httponly=True, secure=True, samesite="Strict")
+    resp.set_cookie(
+        "oidc_id_token", "", expires=0, httponly=True, secure=True, samesite="Strict"
+    )
     return resp
 
 

--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -541,7 +541,7 @@ def logout():
             cache_timeout=-1,
         )
     )
-    resp.set_cookie("oidc_id_token", "", expires=0)
+    resp.set_cookie("oidc_id_token", "", expires=0, httponly=True, secure=True, samesite="Strict")
     return resp
 
 

--- a/patientsearch/logserverhandler.py
+++ b/patientsearch/logserverhandler.py
@@ -24,7 +24,9 @@ class LogServerHandler(logging.Handler):
             "Authorization": f"Bearer {self.jwt}",
         }
         try:
-            response = requests.post(url=self.url, headers=headers, json=log_entry, timeout=30)
+            response = requests.post(
+                url=self.url, headers=headers, json=log_entry, timeout=30
+            )
             response.raise_for_status()
         except RequestException as ex:
             # bootstrap problems - attempt to log to root logger

--- a/patientsearch/logserverhandler.py
+++ b/patientsearch/logserverhandler.py
@@ -24,7 +24,7 @@ class LogServerHandler(logging.Handler):
             "Authorization": f"Bearer {self.jwt}",
         }
         try:
-            response = requests.post(url=self.url, headers=headers, json=log_entry)
+            response = requests.post(url=self.url, headers=headers, json=log_entry, timeout=30)
             response.raise_for_status()
         except RequestException as ex:
             # bootstrap problems - attempt to log to root logger

--- a/patientsearch/models/sync.py
+++ b/patientsearch/models/sync.py
@@ -65,20 +65,20 @@ def HAPI_request(
         headers = {"Cache-Control": "no-cache"}
         try:
             resp = requests.get(
-                url, auth=BearerAuth(token), headers=headers, params=params
+                url, auth=BearerAuth(token), headers=headers, params=params, timeout=30
             )
         except requests.exceptions.ConnectionError as error:
             current_app.logger.exception(error)
             raise RuntimeError("EMR FHIR store inaccessible")
     elif VERB == "POST":
-        resp = requests.post(url, auth=BearerAuth(token), json=resource)
+        resp = requests.post(url, auth=BearerAuth(token), json=resource, timeout=30)
     elif VERB == "PUT":
-        resp = requests.put(url, auth=BearerAuth(token), json=resource)
+        resp = requests.put(url, auth=BearerAuth(token), json=resource, timeout=30)
     elif VERB == "DELETE":
         # Only enable deletion of resource by id
         if not resource_id:
             raise ValueError("'resource_id' required for DELETE")
-        resp = requests.delete(url, auth=BearerAuth(token))
+        resp = requests.delete(url, auth=BearerAuth(token), timeout=30)
     else:
         raise ValueError(f"Invalid HTTP method: {method}")
 
@@ -124,7 +124,7 @@ def external_request(token, resource_type, params):
     search_params = dict(deepcopy(params))  # Necessary on ImmutableMultiDict
     search_params["DEA"] = user.get("DEA")
     url = current_app.config.get("EXTERNAL_FHIR_API") + resource_type
-    resp = requests.get(url, auth=BearerAuth(token), params=search_params)
+    resp = requests.get(url, auth=BearerAuth(token), params=search_params, timeout=30)
     try:
         resp.raise_for_status()
     except requests.exceptions.HTTPError as err:


### PR DESCRIPTION
As identified by semgrep:
- add timeouts to all remote `requests` calls
- add secure/missing parameters to `set_cookie` call