### PR TITLE
allow timeout to be configurable

### DIFF
--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -40,6 +40,7 @@ const useStyles = makeStyles((theme) => ({
 let expiredIntervalId = 0;
 let expiresIn = null;
 let refresh = false;
+let retryAttempts = 0;
 
 export default function TimeoutModal() {
   const classes = useStyles(theme);
@@ -121,6 +122,8 @@ export default function TimeoutModal() {
           "Failed to retrieve token data",
           error && error.status ? "status " + error.status : ""
         );
+        //try again?
+        initTimeoutTracking();
       }
     );
   };
@@ -211,7 +214,10 @@ export default function TimeoutModal() {
   useEffect(() => {
     clearExpiredIntervalId();
     setDisabled(appSettings["ENABLE_INACTIVITY_TIMEOUT"]?false:true);
-    initTimeoutTracking();
+    if (retryAttempts < 2) {
+      initTimeoutTracking();
+      retryAttempts++;
+    } else clearExpiredIntervalId();
   }, [appSettings]);
 
   return (

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -141,10 +141,6 @@ export default function TimeoutModal() {
     setOpen(false);
   };
 
-  const goHome = () => {
-    window.location = "/";
-  }
-
   const reLoad = () => {
     handleClose();
     //To force-request a new Access Token (when one is about to expire, but still valid)

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -95,9 +95,12 @@ export default function TimeoutModal() {
               return;
             }
             if (tokenAboutToExpire) {
-              if (!refreshTokenOnVentilator && disabled) {
+              if (disabled) {
                 //automatically refresh the session IF access token is about to expire AND refresh token has not expired yet
-                setTimeout(() => reLoad(), 5000);
+                setTimeout(() => { 
+                  if (refreshTokenOnVentilator) handleLogout();
+                  else reLoad();
+                }, 5000);
               }
               cleanUpModal();
               if (!open) handleOpen();
@@ -116,7 +119,6 @@ export default function TimeoutModal() {
           handleLogout();
           return;
         }
-        clearExpiredIntervalId();
         console.log(
           "Failed to retrieve token data",
           error && error.status ? "status " + error.status : ""
@@ -188,7 +190,7 @@ export default function TimeoutModal() {
             </span>}
             {disabled && <div>
               <div>Your session is about to expire.</div>
-              <div className={classes.infoDescription}>One moment while your browser session is refreshed....</div>
+              {refresh && <div className={classes.infoDescription}>One moment while your browser session is refreshed....</div>}
             </div>}
           </React.Fragment>
         )}

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -138,7 +138,7 @@ export default function TimeoutModal() {
     }
     retryAttempts = 0;
     clearExpiredIntervalId();
-  }
+  };
 
   const initTimeoutTracking = () => {
     expiredIntervalId = setInterval(

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -127,7 +127,10 @@ export default function TimeoutModal() {
         if (retryAttempts < 2) {
           initTimeoutTracking();
           retryAttempts++;
-        } else clearExpiredIntervalId();
+        } else {
+          retryAttempts = 0;
+          clearExpiredIntervalId();
+        }
       }
     );
   };

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -73,8 +73,7 @@ export default function TimeoutModal() {
             let refreshTokenExpiresIn = parseFloat(
               tokenData["refresh_expires_in"]
             );
-            let refreshTokenOnVentilator =
-              refreshTokenExpiresIn < accessTokenExpiresIn;
+            let refreshTokenOnVentilator = (refreshTokenExpiresIn === 0) || (refreshTokenExpiresIn < accessTokenExpiresIn);
             //in seconds
             //1. check if refresh token will expire before access token first
             //2. check if access token will expire

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -73,7 +73,7 @@ export default function TimeoutModal() {
             let refreshTokenExpiresIn = parseFloat(
               tokenData["refresh_expires_in"]
             );
-            let refreshTokenOnVentilator = (refreshTokenExpiresIn === 0) || (refreshTokenExpiresIn < accessTokenExpiresIn);
+            let refreshTokenOnVentilator = (!tokenData["valid"] && refreshTokenExpiresIn === 0) || (refreshTokenExpiresIn < accessTokenExpiresIn);
             //in seconds
             //1. check if refresh token will expire before access token first
             //2. check if access token will expire

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -182,8 +182,8 @@ export default function TimeoutModal() {
               <span className={classes.expiredDisplay}>{getExpiresInDisplay(expiresIn)}</span>.
             </span>}
             {disabled && <div>
-              <div>Your session is about to expired.</div>
-              <div className={classes.infoDescription}>One moment while your browser session is being refreshed....</div>
+              <div>Your session is about to expire.</div>
+              <div className={classes.infoDescription}>One moment while your browser session is refreshed....</div>
             </div>}
           </React.Fragment>
         )}
@@ -209,11 +209,9 @@ export default function TimeoutModal() {
     </div>
   );
   useEffect(() => {
+    clearExpiredIntervalId();
     setDisabled(appSettings["ENABLE_INACTIVITY_TIMEOUT"]?false:true);
     initTimeoutTracking();
-    return () => {
-      clearExpiredIntervalId();
-    };
   }, [appSettings]);
 
   return (

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -119,7 +119,7 @@ export default function TimeoutModal() {
         clearExpiredIntervalId();
         console.log(
           "Failed to retrieve token data",
-          error ? error.statusText : ""
+          error && error.status ? "status " + error.status : ""
         );
       }
     );
@@ -140,6 +140,10 @@ export default function TimeoutModal() {
     clearExpiredIntervalId();
     setOpen(false);
   };
+
+  const goHome = () => {
+    window.location = "/";
+  }
 
   const reLoad = () => {
     handleClose();

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -73,7 +73,7 @@ export default function TimeoutModal() {
             let refreshTokenExpiresIn = parseFloat(
               tokenData["refresh_expires_in"]
             );
-            let refreshTokenOnVentilator = (!tokenData["valid"] && refreshTokenExpiresIn === 0) || (refreshTokenExpiresIn < accessTokenExpiresIn);
+            let refreshTokenOnVentilator = (refreshTokenExpiresIn < accessTokenExpiresIn);
             //in seconds
             //1. check if refresh token will expire before access token first
             //2. check if access token will expire

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -73,7 +73,7 @@ export default function TimeoutModal() {
             let refreshTokenExpiresIn = parseFloat(
               tokenData["refresh_expires_in"]
             );
-            let refreshTokenOnVentilator = (refreshTokenExpiresIn < accessTokenExpiresIn);
+            let refreshTokenOnVentilator = (!tokenData["valid"] && refreshTokenExpiresIn === 0) || (refreshTokenExpiresIn < accessTokenExpiresIn);
             //in seconds
             //1. check if refresh token will expire before access token first
             //2. check if access token will expire

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -123,7 +123,10 @@ export default function TimeoutModal() {
           error && error.status ? "status " + error.status : ""
         );
         //try again?
-        initTimeoutTracking();
+        if (retryAttempts < 2) {
+          initTimeoutTracking();
+          retryAttempts++;
+        } else clearExpiredIntervalId();
       }
     );
   };
@@ -214,10 +217,7 @@ export default function TimeoutModal() {
   useEffect(() => {
     clearExpiredIntervalId();
     setDisabled(appSettings["ENABLE_INACTIVITY_TIMEOUT"]?false:true);
-    if (retryAttempts < 2) {
-      initTimeoutTracking();
-      retryAttempts++;
-    } else clearExpiredIntervalId();
+    initTimeoutTracking();
   }, [appSettings]);
 
   return (

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -97,7 +97,7 @@ export default function TimeoutModal() {
             if (tokenAboutToExpire) {
               if (disabled) {
                 //automatically refresh the session IF access token is about to expire AND refresh token has not expired yet
-                setTimeout(() => { 
+                setTimeout(() => {
                   if (refreshTokenOnVentilator) handleLogout();
                   else reLoad();
                 }, 5000);
@@ -107,7 +107,7 @@ export default function TimeoutModal() {
             }
           } catch (e) {
             console.log(`Error occurred parsing token data ${e}`);
-            clearExpiredIntervalId();
+            reTry();
             return;
           }
         }
@@ -123,17 +123,22 @@ export default function TimeoutModal() {
           "Failed to retrieve token data",
           error && error.status ? "status " + error.status : ""
         );
-        //try again?
-        if (retryAttempts < 2) {
-          initTimeoutTracking();
-          retryAttempts++;
-        } else {
-          retryAttempts = 0;
-          clearExpiredIntervalId();
-        }
+        //attempt retry if error
+        reTry();
       }
     );
   };
+
+  const reTry = () => {
+    //try again?
+    if (retryAttempts < 2) {
+      initTimeoutTracking();
+      retryAttempts++;
+      return;
+    }
+    retryAttempts = 0;
+    clearExpiredIntervalId();
+  }
 
   const initTimeoutTracking = () => {
     expiredIntervalId = setInterval(

--- a/patientsearch/src/js/components/TimeoutModal.js
+++ b/patientsearch/src/js/components/TimeoutModal.js
@@ -177,11 +177,14 @@ export default function TimeoutModal() {
         )}
         {expiresIn && expiresIn != 0 && (
           <React.Fragment>
-            <span>
+            {!disabled && <span>
               Your session will expired in approximately
               <span className={classes.expiredDisplay}>{getExpiresInDisplay(expiresIn)}</span>.
-            </span>
-            {disabled && <div className={classes.infoDescription}>One moment while your browser session is being refreshed....</div>}
+            </span>}
+            {disabled && <div>
+              <div>Your session is about to expired.</div>
+              <div className={classes.infoDescription}>One moment while your browser session is being refreshed....</div>
+            </div>}
           </React.Fragment>
         )}
         <div className="buttons-container">

--- a/patientsearch/src/js/components/Utility.js
+++ b/patientsearch/src/js/components/Utility.js
@@ -29,7 +29,7 @@ export function sendRequest (url, params) {
 
       // Handle network errors
       req.onerror = function() {
-        reject(Error("Network Error"));
+        reject(req);
       };
 
       // Make the request


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180827785
Allow Inactivity timeout to be disabled by configuration (`ENABLE_INACTIVITY_TIMEOUT`).
If enabled, function as-is (`default; ENABLE_INACTIVITY_TIMEOUT=true`).
If disabled (`ENABLE_INACTIVITY_TIMEOUT=false`),  session will automatically be refreshed by a browser refresh with a popup modal indicating as such (see screenshot)
![patientSearchTimeout](https://user-images.githubusercontent.com/12942714/150613789-8a6f01bd-044c-4fe2-aaad-f4a9ff76a75a.png)

