### PR TITLE
address frontend issues raised by semgrep report where possible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7396,10 +7396,9 @@
       }
     },
     "dompurify": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.8.tgz",
-      "integrity": "sha512-9H0UL59EkDLgY3dUFjLV6IEUaHm5qp3mxSqWw7Yyx4Zhk2Jn2cmLe+CNPP3xy13zl8Bqg+0NehQzkdMoVhGRww==",
-      "optional": true
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.4.tgz",
+      "integrity": "sha512-6BVcgOAVFXjI0JTjEvZy901Rghm+7fDQOrNIcxB4+gdhj6Kwp6T9VBhBY/AbagKHJocRkDYGd6wvI+p4/10xtQ=="
     },
     "domutils": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "classnames": "^2.3.1",
     "clsx": "^1.1.0",
     "date-fns": "^2.27.0",
+    "dompurify": "^2.3.4",
     "es6-promise": "^4.2.8",
     "material-table": "^1.69.3",
     "react": "^16.14.0",

--- a/patientsearch/src/js/components/Agreement.js
+++ b/patientsearch/src/js/components/Agreement.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import DOMPurify from "dompurify";
 import { makeStyles } from "@material-ui/core/styles";
 import DateFnsUtils from "@date-io/date-fns";
 import isValid from "date-fns/isValid";
@@ -14,11 +15,11 @@ import InputLabel from "@material-ui/core/InputLabel";
 import Paper from "@material-ui/core/Paper";
 import Snackbar from "@material-ui/core/Snackbar";
 import Typography from "@material-ui/core/Typography";
-import MuiAlert from "@material-ui/lab/Alert";
 import {
   MuiPickersUtilsProvider,
   KeyboardDatePicker,
 } from "@material-ui/pickers";
+import Alert from "./Alert";
 import EditButtonGroup from "./EditButtonGroup";
 import Error from "./Error";
 import FormattedInput from "./FormattedInput";
@@ -120,9 +121,6 @@ const useStyles = makeStyles({
     position: "relative"
   }
 });
-function Alert(props) {
-  return <MuiAlert elevation={6} variant="filled" {...props} />;
-}
 
 export default function Agreement(props) {
   const classes = useStyles();
@@ -515,7 +513,7 @@ export default function Agreement(props) {
             Latest Controlled Substance Agreement
           </Typography>
           {historyInitialized && hasHistory() && <div>
-            {!editMode && <span dangerouslySetInnerHTML={{ __html: displayHistory() }}></span>}
+            {!editMode && <span dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(displayHistory()) }}></span>}
             {editMode && displayEditHistory()}
             <EditButtonGroup
               onEnableEditMode={handleEnableEditMode}
@@ -580,9 +578,7 @@ export default function Agreement(props) {
         </Paper>}
         {/* submission feedback UI */}
         <Snackbar open={snackOpen} autoHideDuration={3000} onClose={handleSnackClose}>
-          <Alert onClose={handleSnackClose} severity="success">
-            Request processed successfully.
-          </Alert>
+          <Alert onClose={handleSnackClose} severity="success" message="Request processed successfully."></Alert>
         </Snackbar>
         <div className={classes.errorContainer}>
           {error && <Error message={error}></Error>}

--- a/patientsearch/src/js/components/Alert.js
+++ b/patientsearch/src/js/components/Alert.js
@@ -1,0 +1,24 @@
+import React from "react";
+import PropTypes from "prop-types";
+import DOMPurify from "dompurify";
+import renderHTML from "react-render-html";
+import MuiAlert from "@material-ui/lab/Alert";
+
+export default function Alert(props) {
+    const variant = props.variant?props.variant:"filled";
+    const severity = props.severity?props.severity:"error";
+  return <MuiAlert
+            elevation={6}
+            variant={variant}
+            severity={severity}
+            onClose={props.onClose}>
+              {props.message && renderHTML(DOMPurify.sanitize(props.message))}
+        </MuiAlert>;
+}
+
+Alert.propTypes = {
+  message: PropTypes.string.isRequired,
+  severity: PropTypes.string,
+  variant: PropTypes.string,
+  onClose: PropTypes.func
+};

--- a/patientsearch/src/js/components/EditButtonGroup.js
+++ b/patientsearch/src/js/components/EditButtonGroup.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import DOMPurify from "dompurify";
 import { makeStyles } from "@material-ui/core/styles";
 import ClearIcon from "@material-ui/icons/Clear";
 import Delete from "@material-ui/icons/Delete";
@@ -69,7 +70,7 @@ export default function EditButtonGroup(props) {
             <div className="warning-modal-body">
                 <div className="warning-modal-content">
                     <h3>Are you sure you want to remove this entry?</h3>
-                    {props.entryDescription && <div className={classes.description}  dangerouslySetInnerHTML={{ __html: props.entryDescription}}></div>}
+                    {props.entryDescription && <div className={classes.description}  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(props.entryDescription)}}></div>}
                     <div>
                         <Button variant="contained" color="primary" onClick={handleDelete} className={classes.delYesButton}>Yes</Button>
                         <Button variant="outlined" color="primary" onClick={handleDeleteModalClose}>No</Button>

--- a/patientsearch/src/js/components/Error.js
+++ b/patientsearch/src/js/components/Error.js
@@ -1,12 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import renderHTML from "react-render-html";
-import MuiAlert from "@material-ui/lab/Alert";
 import { makeStyles } from "@material-ui/core/styles";
-
-function Alert(props) {
-  return <MuiAlert elevation={6} variant="filled" {...props} />;
-}
+import Alert from "./Alert";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -27,9 +22,7 @@ export default function ErrorMessage(props) {
   const classes = useStyles();
   return (
     <div className={classes.root} style={props.style}>
-      <Alert severity="error">
-        {props.message && renderHTML(props.message)}
-      </Alert>
+      <Alert severity="error" message={props.message}></Alert>
     </div>
   );
 }

--- a/patientsearch/src/js/components/FormattedInput.js
+++ b/patientsearch/src/js/components/FormattedInput.js
@@ -23,6 +23,7 @@ function TextMaskCustom(props) {
         ref={(ref) => {
           inputRef(ref ? ref.inputElement : null);
         }}
+        keepCharPositions={true}
         mask={props.mask ? props.mask : [/[1-2]/, /[0,9]/, /\d/, /\d/, "-", /\d/, /\d/, "-", /\d/, /\d/]}
         placeholderChar={"\u2000"}
         showMask

--- a/patientsearch/src/js/components/Info.js
+++ b/patientsearch/src/js/components/Info.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import DOMPurify from "dompurify";
 import { makeStyles } from "@material-ui/core/styles";
 import Button from "@material-ui/core/Button";
 import CircularProgress from "@material-ui/core/CircularProgress";
@@ -141,7 +142,7 @@ export default function Info(props) {
         <div className={classes.container}>
           {/* intro text, e.g. HTML block 1 */}
           <div className={classes.introText}>
-            <div dangerouslySetInnerHTML={{ __html: getIntroText() }}></div>
+            <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(getIntroText()) }}></div>
           </div>
           {/* logo image */}
           {siteID && (
@@ -171,7 +172,7 @@ export default function Info(props) {
               align="center"
               className={classes.title}
             >
-              <div dangerouslySetInnerHTML={{ __html: getBodyText() }}></div>
+              <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(getBodyText()) }}></div>
             </Typography>
           </div>
         </div>

--- a/patientsearch/src/js/components/SiteLogo.js
+++ b/patientsearch/src/js/components/SiteLogo.js
@@ -49,12 +49,15 @@ export default function SiteLogo(props) {
       return;
     }
   }
+  const getSiteImagePath = () => {
+    return "/static/" + getSiteId() + "/img/logo.png";
+  }
 
   return (
     <div className={classes.container}>
       {getSiteId() && (
         <img
-          src={"/static/" + getSiteId() + "/img/logo.png"}
+          src={getSiteImagePath()}
           onLoad={handleImageLoaded}
           onError={handleImageLoadError}
         ></img>

--- a/patientsearch/src/js/components/SiteLogo.js
+++ b/patientsearch/src/js/components/SiteLogo.js
@@ -51,7 +51,7 @@ export default function SiteLogo(props) {
   }
   const getSiteImagePath = () => {
     return "/static/" + getSiteId() + "/img/logo.png";
-  }
+  };
 
   return (
     <div className={classes.container}>

--- a/patientsearch/src/js/components/UrineScreen.js
+++ b/patientsearch/src/js/components/UrineScreen.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import DOMPurify from "dompurify";
 import { makeStyles} from "@material-ui/core/styles";
 import DateFnsUtils from "@date-io/date-fns";
 import isValid from "date-fns/isValid";
@@ -19,8 +20,8 @@ import Paper from "@material-ui/core/Paper";
 import Select from "@material-ui/core/Select";
 import Snackbar from "@material-ui/core/Snackbar";
 import Typography from "@material-ui/core/Typography";
-import MuiAlert from "@material-ui/lab/Alert";
 import  {MuiPickersUtilsProvider, KeyboardDatePicker } from "@material-ui/pickers";
+import Alert from "./Alert";
 import EditButtonGroup from "./EditButtonGroup";
 import Error from "./Error";
 import HistoryTable from "./HistoryTable";
@@ -142,9 +143,6 @@ const useStyles = makeStyles({
         position: "relative"
     }
 });
-function Alert(props) {
-    return <MuiAlert elevation={6} variant="filled" {...props} />;
-}
 
 export default function UrineScreen(props) {
     const classes = useStyles();
@@ -624,7 +622,7 @@ export default function UrineScreen(props) {
                         Last Urine Drug Screen
                     </Typography>
                     {historyInitialized && hasHistory() && <div>
-                        {!editMode && <span dangerouslySetInnerHTML={{ __html: displayHistory()}}></span>}
+                        {!editMode && <span dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(displayHistory())}}></span>}
                         {editMode && displayEditHistoryByRow(0)}
                         <EditButtonGroup
                             onEnableEditMode={handleEnableEditMode}
@@ -673,7 +671,7 @@ export default function UrineScreen(props) {
                 </Paper>}
                 {/* feedback snack popup */}
                 <Snackbar open={snackOpen} autoHideDuration={3000} onClose={handleSnackClose}>
-                    <Alert onClose={handleSnackClose} severity="success">Request processed successfully.</Alert>
+                    <Alert onClose={handleSnackClose} severity="success" message="Request processed successfully."></Alert>
                 </Snackbar>
                 {/* error message UI */}
                 <div className={classes.errorContainer}>

--- a/patientsearch/src/js/components/Version.js
+++ b/patientsearch/src/js/components/Version.js
@@ -39,7 +39,7 @@ export default function Version(props) {
       ? `https://github.com/uwcirg/cosri-environments/releases/tag/${version}`
       : "";
     return link ? (
-      <a href={link} target="_blank" rel="noreferrer">
+      <a href={link} target="_blank" rel="noreferrer" noopener="true">
         {version}
       </a>
     ) : (


### PR DESCRIPTION
- Address cross-site scripting (XSS) attack for html injection (using `sanitize` function from dompurify lib to sanitize html as per suggestion)
- Add missing 'noopener' on an anchor tag
- Remove spreading of props from Alert component element by explicitly passing in props (also refactor out repetitive code for Alert component) **Note**  there are issues related to this raised for component elements (e.g. Icon & Detail panel) used by the Material table component. Holding off on addressing those for now as I need to understand how to best change them without breaking existing functionalities