### PR TITLE
Consider JWT roles for dashboard authorization

### DIFF
--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -13,7 +13,7 @@ from flask import (
 from flask.json import JSONEncoder
 import jwt
 import requests
-from werkzeug.exceptions import Unauthorized
+from werkzeug.exceptions import Unauthorized, Forbidden
 
 from patientsearch.audit import audit_entry, audit_HAPI_change
 from patientsearch.models import (
@@ -92,7 +92,7 @@ def validate_auth():
     current_app.logger.warn(
         f"User's roles: {user_has}  don't include any from REQUIRED_ROLES: {required}"
     )
-    raise Unauthorized("User lacks adequate 'role'; can't continue")
+    raise Forbidden("User lacks adequate 'role'; can't continue")
 
 
 def current_user_info(token):

--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -85,11 +85,13 @@ def validate_auth():
         token,
         options={"verify_signature": False, "verify_aud": False},
     )
-    user_has = dict_token.get('realm_access', {}).get('roles', [])
+    user_has = dict_token.get("realm_access", {}).get("roles", [])
     if set(required).intersection(set(user_has)):
         return token
 
-    current_app.logger.warn(f"User's roles: {user_has}  don't include any from REQUIRED_ROLES: {required}")
+    current_app.logger.warn(
+        f"User's roles: {user_has}  don't include any from REQUIRED_ROLES: {required}"
+    )
     raise Unauthorized("User lacks adequate 'role'; can't continue")
 
 

--- a/patientsearch/config.py
+++ b/patientsearch/config.py
@@ -17,6 +17,7 @@ def load_json_config(potential_json_string):
 ENABLE_INACTIVITY_TIMEOUT = (
     os.getenv("ENABLE_INACTIVITY_TIMEOUT", "true").lower() == "true"
 )
+FORBIDDEN_TEXT = os.getenv("FORBIDDEN_TEXT", "Your account is not authorized for access, please contact an administrator")
 LANDING_INTRO = os.getenv("LANDING_INTRO", "")
 LANDING_BUTTON_TEXT = os.getenv("LANDING_BUTTON_TEXT", "")
 LANDING_BODY = os.getenv("LANDING_BODY", "")

--- a/patientsearch/config.py
+++ b/patientsearch/config.py
@@ -77,4 +77,5 @@ else:
 OIDC_ID_TOKEN_COOKIE_SECURE = False
 OIDC_REQUIRE_VERIFIED_EMAIL = False
 OIDC_SCOPES = ["email", "openid", "roles"]
+REQUIRED_ROLES = json.loads(os.getenv("REQUIRED_ROLES", "[]"))
 UDS_LAB_TYPES = json.loads(os.getenv("UDS_LAB_TYPES", "[]"))

--- a/patientsearch/config.py
+++ b/patientsearch/config.py
@@ -17,7 +17,10 @@ def load_json_config(potential_json_string):
 ENABLE_INACTIVITY_TIMEOUT = (
     os.getenv("ENABLE_INACTIVITY_TIMEOUT", "true").lower() == "true"
 )
-FORBIDDEN_TEXT = os.getenv("FORBIDDEN_TEXT", "Your account is not authorized for access, please contact an administrator")
+FORBIDDEN_TEXT = os.getenv(
+    "FORBIDDEN_TEXT",
+    "Your account is not authorized for access, please contact an administrator",
+)
 LANDING_INTRO = os.getenv("LANDING_INTRO", "")
 LANDING_BUTTON_TEXT = os.getenv("LANDING_BUTTON_TEXT", "")
 LANDING_BODY = os.getenv("LANDING_BODY", "")

--- a/patientsearch/config.py
+++ b/patientsearch/config.py
@@ -14,8 +14,9 @@ def load_json_config(potential_json_string):
         return json.loads(potential_json_string)
 
 
-
-ENABLE_INACTIVITY_TIMEOUT = os.getenv("ENABLE_INACTIVITY_TIMEOUT", "true").lower() == "true"
+ENABLE_INACTIVITY_TIMEOUT = (
+    os.getenv("ENABLE_INACTIVITY_TIMEOUT", "true").lower() == "true"
+)
 LANDING_INTRO = os.getenv("LANDING_INTRO", "")
 LANDING_BUTTON_TEXT = os.getenv("LANDING_BUTTON_TEXT", "")
 LANDING_BODY = os.getenv("LANDING_BODY", "")

--- a/patientsearch/src/js/Logout.js
+++ b/patientsearch/src/js/Logout.js
@@ -4,13 +4,29 @@ import CssBaseline from "@material-ui/core/CssBaseline";
 import { ThemeProvider } from "@material-ui/styles";
 import Button from "@material-ui/core/Button";
 import Typography from "@material-ui/core/Typography";
+import Alert from "./components/Alert";
 import Header from "./components/Header";
 import {getUrlParameter} from "./components/Utility";
 import SettingContextProvider from "./context/SettingContextProvider";
+import { getAppSettings } from "./context/SettingContextProvider";
 import theme from "./context/theme";
 import "../styles/app.scss";
 
-function getMessage() {
+// Error message, e.g. forbidden error
+const AlertMessage = () => {
+    if (!getUrlParameter("forbidden")) return ""; // look for forbidden message for now, can be others as well
+    const appSettings = getAppSettings();
+    const [message, setMessage] = React.useState("");
+    const [ready, setReady] = React.useState(false);
+    React.useEffect(() => {
+        if (appSettings && appSettings["FORBIDDEN_TEXT"]) {
+            setMessage(appSettings["FORBIDDEN_TEXT"]);
+            setReady(true);
+        }
+    }, [appSettings]);
+    return <div>{ready && <div className="alert-container"><Alert message={message} elevation={0}></Alert></div>}</div>;
+}
+const getMessage = () => {
     if (getUrlParameter("user_initiated")) return "You have been logged out as requested.";
     if (getUrlParameter("timeout")) return "Your session has expired. For security purposes, we recommend closing your browser window. You can always log back in.";
     return "You have been logged out.";
@@ -26,6 +42,7 @@ render(
                     <Typography component="h4" variant="h5" color="inherit" align="center">
                         {getMessage()}
                     </Typography>
+                    <AlertMessage></AlertMessage>
                     <br/>
                     <Button color="primary" href="/home" align="center" variant="outlined" size="large">Click here to log in</Button>
                 </div>

--- a/patientsearch/src/js/Logout.js
+++ b/patientsearch/src/js/Logout.js
@@ -25,12 +25,12 @@ const AlertMessage = () => {
         }
     }, [appSettings]);
     return <div>{ready && <div className="alert-container"><Alert message={message} elevation={0}></Alert></div>}</div>;
-}
+};
 const getMessage = () => {
     if (getUrlParameter("user_initiated")) return "You have been logged out as requested.";
     if (getUrlParameter("timeout")) return "Your session has expired. For security purposes, we recommend closing your browser window. You can always log back in.";
     return "You have been logged out.";
-}
+};
 // logout entry point
 render(
     <SettingContextProvider>

--- a/patientsearch/src/js/components/Alert.js
+++ b/patientsearch/src/js/components/Alert.js
@@ -7,8 +7,9 @@ import MuiAlert from "@material-ui/lab/Alert";
 export default function Alert(props) {
     const variant = props.variant?props.variant:"filled";
     const severity = props.severity?props.severity:"error";
+    const elevation = props.elevation || props.elevation === 0?props.elevation:6;
   return <MuiAlert
-            elevation={6}
+            elevation={elevation}
             variant={variant}
             severity={severity}
             onClose={props.onClose}>
@@ -20,5 +21,6 @@ Alert.propTypes = {
   message: PropTypes.string.isRequired,
   severity: PropTypes.string,
   variant: PropTypes.string,
+  elevation: PropTypes.number,
   onClose: PropTypes.func
 };

--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -575,6 +575,10 @@ export default function PatientListTable() {
       window.location = "/logout?unauthorized=true";
       return;
     }
+    if (e && e.status === 403) {
+      window.location = "/logout?forbidden=true";
+      return;
+    }
     setErrorMessage(
       isString(e)
         ? e

--- a/patientsearch/src/styles/app.scss
+++ b/patientsearch/src/styles/app.scss
@@ -75,6 +75,12 @@ html {
     border-width: 2px;
     margin-top: 16px;
   }
+  .alert-container {
+    margin-top: 24px;
+    .MuiAlert-message {
+      font-size: 16px;
+    }
+  }
 }
 @media (min-width: 699px) {
   .logout-container {


### PR DESCRIPTION
Dashboard now takes optional config `REQUIRED_ROLES` - a list of strings.  If REQUIRED_ROLES is non empty, and the user doesn't have at least one of the roles named, a 403(Forbidden) status will be raised.

Dashboard now has optional config `FORBIDDEN_TEXT` to manage a per-instance response for users that have a value user/password, but do not have a required role.

Screenshot of UI when 403 error occurs:
<img width="764" alt="Screen Shot 2022-05-06 at 1 05 14 PM" src="https://user-images.githubusercontent.com/12942714/167210453-da26bd03-3c9c-4a61-b2e3-5caf05edfa2a.png">


See also related cosri-environments change: https://github.com/uwcirg/cosri-environments/pull/75
