### PR TITLE
Make EXTERNAL_FHIR_API config optional

### DIFF
--- a/patientsearch/config.py
+++ b/patientsearch/config.py
@@ -14,8 +14,9 @@ def load_json_config(potential_json_string):
         return json.loads(potential_json_string)
 
 
-
-ENABLE_INACTIVITY_TIMEOUT = os.getenv("ENABLE_INACTIVITY_TIMEOUT", "true").lower() == "true"
+ENABLE_INACTIVITY_TIMEOUT = (
+    os.getenv("ENABLE_INACTIVITY_TIMEOUT", "true").lower() == "true"
+)
 LANDING_INTRO = os.getenv("LANDING_INTRO", "")
 LANDING_BUTTON_TEXT = os.getenv("LANDING_BUTTON_TEXT", "")
 LANDING_BODY = os.getenv("LANDING_BODY", "")

--- a/patientsearch/config.py
+++ b/patientsearch/config.py
@@ -49,7 +49,7 @@ LOG_LEVEL = os.environ.get("LOG_LEVEL", "DEBUG").upper()
 
 VERSION_STRING = os.getenv("VERSION_STRING")
 
-EXTERNAL_FHIR_API = os.getenv("EXTERNAL_FHIR_API")
+EXTERNAL_FHIR_API = os.getenv("EXTERNAL_FHIR_API", "")
 MAP_API = os.getenv("MAP_API")
 
 SOF_CLIENT_LAUNCH_URL = os.getenv("SOF_CLIENT_LAUNCH_URL")

--- a/patientsearch/models/sync.py
+++ b/patientsearch/models/sync.py
@@ -117,6 +117,8 @@ def external_request(token, resource_type, params):
 
     if not resource_type:
         raise ValueError("Required `resource_type` not included")
+    if not current_app.config.get("EXTERNAL_FHIR_API"):
+        raise ValueError("config var EXTERNAL_FHIR_API not defined; can't continue")
 
     user = current_user_info(token)
     if "DEA" not in user:


### PR DESCRIPTION
Not all clients use EXTERNAL_FHIR_API (i.e. used by cosri but not safer) - raise clear exception if needed and not defined.