### PR TITLE
enable hapi put parameters

### DIFF
--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -278,6 +278,7 @@ def post_resource(resource_type):
         audit_HAPI_change(
             user_info=current_user_info(token),
             method=method,
+            params=request.args,
             resource=resource,
             resource_type=resource_type,
         )
@@ -285,6 +286,7 @@ def post_resource(resource_type):
             HAPI_request(
                 token=token,
                 method=method,
+                params=request.args,
                 resource_type=resource_type,
                 resource=resource,
             )

--- a/patientsearch/audit.py
+++ b/patientsearch/audit.py
@@ -36,7 +36,7 @@ def audit_entry(message, level="info", extra=None):
 
 
 def audit_HAPI_change(
-    user_info, method, resource=None, resource_type=None, resource_id=None
+    user_info, method, params=None, resource=None, resource_type=None, resource_id=None
 ):
     rt = resource_type or resource and resource.get("resourceType")
     id = resource_id or resource and resource.get("_id", "")
@@ -48,4 +48,6 @@ def audit_HAPI_change(
     elif resource:
         extra["resource"] = resource
 
+    if params:
+        extra['params'] = params
     audit_entry(message=msg, extra=extra)

--- a/patientsearch/audit.py
+++ b/patientsearch/audit.py
@@ -49,5 +49,5 @@ def audit_HAPI_change(
         extra["resource"] = resource
 
     if params:
-        extra['params'] = params
+        extra["params"] = params
     audit_entry(message=msg, extra=extra)

--- a/patientsearch/models/sync.py
+++ b/patientsearch/models/sync.py
@@ -72,10 +72,12 @@ def HAPI_request(
             raise RuntimeError("EMR FHIR store inaccessible")
     elif VERB == "POST":
         resp = requests.post(
-            url, auth=BearerAuth(token), params=params, json=resource, timeout=30)
+            url, auth=BearerAuth(token), params=params, json=resource, timeout=30
+        )
     elif VERB == "PUT":
         resp = requests.put(
-            url, auth=BearerAuth(token), params=params, json=resource, timeout=30)
+            url, auth=BearerAuth(token), params=params, json=resource, timeout=30
+        )
     elif VERB == "DELETE":
         # Only enable deletion of resource by id
         if not resource_id:
@@ -232,7 +234,8 @@ def internal_patient_search(token, patient):
     """Look up given patient from "internal" HAPI store, returns bundle"""
     params = patient_as_search_params(patient)
     return HAPI_request(
-        token=token, method="GET", resource_type="Patient", params=params)
+        token=token, method="GET", resource_type="Patient", params=params
+    )
 
 
 def sync_patient(token, patient):

--- a/patientsearch/models/sync.py
+++ b/patientsearch/models/sync.py
@@ -71,9 +71,11 @@ def HAPI_request(
             current_app.logger.exception(error)
             raise RuntimeError("EMR FHIR store inaccessible")
     elif VERB == "POST":
-        resp = requests.post(url, auth=BearerAuth(token), params=params, json=resource, timeout=30)
+        resp = requests.post(
+            url, auth=BearerAuth(token), params=params, json=resource, timeout=30)
     elif VERB == "PUT":
-        resp = requests.put(url, auth=BearerAuth(token), params=params, json=resource, timeout=30)
+        resp = requests.put(
+            url, auth=BearerAuth(token), params=params, json=resource, timeout=30)
     elif VERB == "DELETE":
         # Only enable deletion of resource by id
         if not resource_id:
@@ -229,7 +231,8 @@ def patient_as_search_params(patient):
 def internal_patient_search(token, patient):
     """Look up given patient from "internal" HAPI store, returns bundle"""
     params = patient_as_search_params(patient)
-    return HAPI_request(token=token, method="GET", resource_type="Patient", params=params)
+    return HAPI_request(
+        token=token, method="GET", resource_type="Patient", params=params)
 
 
 def sync_patient(token, patient):

--- a/patientsearch/models/sync.py
+++ b/patientsearch/models/sync.py
@@ -71,9 +71,9 @@ def HAPI_request(
             current_app.logger.exception(error)
             raise RuntimeError("EMR FHIR store inaccessible")
     elif VERB == "POST":
-        resp = requests.post(url, auth=BearerAuth(token), json=resource, timeout=30)
+        resp = requests.post(url, auth=BearerAuth(token), params=params, json=resource, timeout=30)
     elif VERB == "PUT":
-        resp = requests.put(url, auth=BearerAuth(token), json=resource, timeout=30)
+        resp = requests.put(url, auth=BearerAuth(token), params=params, json=resource, timeout=30)
     elif VERB == "DELETE":
         # Only enable deletion of resource by id
         if not resource_id:
@@ -193,24 +193,28 @@ def _merge_patient(src_patient, internal_patient, token):
         return internal_patient
     else:
         internal_patient["identifier"] = src_patient["identifier"]
+        params = patient_as_search_params(internal_patient)
         return HAPI_request(
             token=token,
             method="PUT",
+            params=params,
             resource_type="Patient",
             resource=internal_patient,
             resource_id=internal_patient["id"],
         )
 
 
-def internal_patient_search(token, patient):
-    """Look up given patient from "internal" HAPI store, returns bundle"""
+def patient_as_search_params(patient):
+    """Generate HAPI search params from patient resource"""
 
     # Use same parameters sent to external src looking for existing Patient
-    # Note FHIR uses list for 'given', common parameter use defines just one
+    # Note FHIR uses list for 'name' and 'given', common parameter use defines just one
     search_map = (
         ("name.family", "family", ""),
+        ("name[0].family", "family", ""),
         ("name.given", "given", ""),
         ("name.given[0]", "given", ""),
+        ("name[0].given[0]", "given", ""),
         ("birthDate", "birthdate", "eq"),
     )
     search_params = {}
@@ -219,10 +223,13 @@ def internal_patient_search(token, patient):
         match = json_search(path, patient)
         if match and isinstance(match, str):
             search_params[queryterm] = compstr + match
+    return search_params
 
-    return HAPI_request(
-        token=token, method="GET", resource_type="Patient", params=search_params
-    )
+
+def internal_patient_search(token, patient):
+    """Look up given patient from "internal" HAPI store, returns bundle"""
+    params = patient_as_search_params(patient)
+    return HAPI_request(token=token, method="GET", resource_type="Patient", params=params)
 
 
 def sync_patient(token, patient):


### PR DESCRIPTION
Add support for the PUT verb on proxy requests to FHIR.

HAPI was not accepting "new" patients via PUT without the query string parameters we used to define a unique patient.
