### PR TITLE
Remove common bookmark redirect from monitored filters

### DIFF
--- a/patientsearch/extensions.py
+++ b/patientsearch/extensions.py
@@ -7,7 +7,7 @@ class OpenIDConnectRedirect(OpenIDConnect):
 
     def _oidc_error(self, message=None, code=None):
         message = f": {message}" if message is not None else ""
-        current_app.logger.error(f"Error{message}; redirecting to /home")
+        current_app.logger.warn(f"{message}; redirecting to /home, presumably from post-auth bookmark")
         return redirect("/home")
 
 

--- a/patientsearch/extensions.py
+++ b/patientsearch/extensions.py
@@ -7,7 +7,9 @@ class OpenIDConnectRedirect(OpenIDConnect):
 
     def _oidc_error(self, message=None, code=None):
         message = f": {message}" if message is not None else ""
-        current_app.logger.warn(f"{message}; redirecting to /home, presumably from post-auth bookmark")
+        current_app.logger.warn(
+            f"{message}; redirecting to /home, presumably from post-auth bookmark"
+        )
         return redirect("/home")
 
 


### PR DESCRIPTION
Fix for https://www.pivotaltracker.com/story/show/182408879

Users with a post-auth bookmark returning pre-auth generate a log message that is being picked up by the monitoring systems.

Reduce the log level given the common case is not exceptional.