### PR TITLE
sort fix - remove the need for an extra click to sort

### DIFF
--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -951,6 +951,7 @@ export default function PatientListTable() {
             toolbar: false,
             filtering: false,
             sorting: true,
+            thirdSortClick: false,
             search: false,
             showTitle: false,
             headerStyle: {


### PR DESCRIPTION
Current sorting behavior:
When sorting a column, the first click works - the column is sorted.  However, the second click doesn't sort the column in the reverse direction.  Another click is required to sort the column again.

Change:
- turn off the table option that requires a third click for sorting