### PR TITLE
Remove DockerHub

### DIFF
--- a/.github/workflows/build-deliver.yaml
+++ b/.github/workflows/build-deliver.yaml
@@ -31,16 +31,3 @@ jobs:
           # create docker image tags to match git tags
           tag_names: true
           buildargs: VERSION_STRING
-
-      # TODO remove after every *-environments migrated to GHCR
-      - name: Publish to Dockerhub registry
-        # TODO pin to hash
-        uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          name: ${{ github.repository }}
-          # configured at repo settings/secrets
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          # create docker image tags to match git tags
-          tag_names: true
-          buildargs: VERSION_STRING


### PR DESCRIPTION
- Remove DockerHub as secondary image registry
- Only merge after uwcirg/cosri-patientsearch/pull/165, once every *-environments repo is using GHCR (instead of DockerHub)