### PR TITLE
Feature/columns config update

### DIFF
--- a/patientsearch/src/js/components/HistoryTable.js
+++ b/patientsearch/src/js/components/HistoryTable.js
@@ -64,7 +64,7 @@ export default function HistoryTable(props) {
     emptyRowsWhenPaging: false,
     toolbar: false,
     filtering: false,
-    sorting: true,
+    maxColumnSort: 1,
     search: false,
     showTitle: false,
     pageSizeOptions: [5],

--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -234,6 +234,7 @@ export default function PatientListTable() {
       column.field = fieldName;
       column.emptyValue = () => <div datacolumn={`${column.label}`}>--</div>;
       column.render = (rowData) => (
+        /* eslint-disable react/react/no-unknown-property */
         <div datacolumn={`${column.label}`}>{rowData[fieldName]}</div>
       );
       return column;

--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -769,7 +769,6 @@ export default function PatientListTable() {
             return patientResources.map((item) => {
               let subjectId = item.resource.id;
               if (!item.resource["resources"]) item.resource["resources"] = [];
-              console.log("results", results);
               results.forEach((result) => {
                 if (isEmptyArray(result.entry)) return true;
                 item.resource["resources"] = [

--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -232,10 +232,11 @@ export default function PatientListTable() {
       const fieldName = column.label.toLowerCase().replace(/\s/g, "_");
       column.title = column.label;
       column.field = fieldName;
-      column.emptyValue = () => <div datacolumn={`${column.label}`}>--</div>;
+      /* eslint-disable react/no-unknown-property */
+      column.emptyValue = () => <div dataColumn={`${column.label}`}>--</div>;
       column.render = (rowData) => (
-        /* eslint-disable react/react/no-unknown-property */
-        <div datacolumn={`${column.label}`}>{rowData[fieldName]}</div>
+        /* eslint-disable react/no-unknown-property */
+        <div dataColumn={`${column.label}`}>{rowData[fieldName]}</div>
       );
       return column;
     });

--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -25,6 +25,7 @@ import {
   addMamotoTracking,
   fetchData,
   getLocalDateTimeString,
+  getPreferredUserNameFromToken,
   getUrlParameter,
   getRolesFromToken,
   getClientsByRequiredRoles,
@@ -608,7 +609,14 @@ export default function PatientListTable() {
       const orderField = query.orderByCollection[0];
       const cols = getColumns();
       const orderByField = cols[orderField.orderBy]; // orderBy is the index of the column
-      if (orderByField) sortField = constants.fieldNameMaps[orderByField.field]; // translate to fhir field name
+      if (orderByField) {
+        const matchedColumn = cols.filter(
+          (col) => col.field === orderByField.field
+        );
+        if (matchedColumn.length && matchedColumn[0].sortBy) {
+          sortField = matchedColumn[0].sortBy;
+        } else sortField = constants.fieldNameMaps[orderByField.field]; // translate to fhir field name
+      }
       sortDirection = orderField.orderDirection;
     }
     if (!sortField) {
@@ -618,6 +626,7 @@ export default function PatientListTable() {
         : "_lastUpdated";
       sortDirection = returnObj ? returnObj.defaultSort : "desc";
     }
+
     if (!sortDirection) {
       sortDirection = "desc";
     }

--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -726,7 +726,8 @@ export default function PatientListTable() {
           );
           const eligibleRequests = additionalParams.filter(
             (request) =>
-              typeof request === "string" || typeof request === "object"
+              typeof request === "string" ||
+              (typeof request === "object" && request.resourceType)
           );
           const resolvedData = {
             data: responseData,
@@ -776,7 +777,9 @@ export default function PatientListTable() {
                   ...result.entry
                     .filter((o) => {
                       const matchedResource = additionalParams.filter(
-                        (item) => item.resourceType === o.resource.resourceType
+                        (item) =>
+                          item.resourceType &&
+                          item.resourceType === o.resource.resourceType
                       );
                       const referenceElementName =
                         matchedResource.length > 0

--- a/patientsearch/src/js/helpers/utility.js
+++ b/patientsearch/src/js/helpers/utility.js
@@ -434,7 +434,7 @@ export function addMamotoTracking(siteId, userId) {
 
 /*
  * @param objDate of type Date object
- * return text display of time in hour or day
+ * @returns text display of time ago as string e.g. < 50 seconds, < 1 hour, 1 day 2 hours, 3 hours, 3 days
  */
 export function getTimeAgoDisplay(objDate) {
   if (!objDate) return "";

--- a/patientsearch/src/js/helpers/utility.js
+++ b/patientsearch/src/js/helpers/utility.js
@@ -439,6 +439,7 @@ export function addMamotoTracking(siteId, userId) {
 export function getTimeAgoDisplay(objDate) {
   if (!objDate) return "";
   const today = new Date();
+  const total = today - objDate;
   const seconds = Math.round((today - objDate) / 1000);
   const minutes = Math.round(seconds / 60);
   const hours = Math.round(minutes / 60);
@@ -453,7 +454,7 @@ export function getTimeAgoDisplay(objDate) {
     return `${hours} hour${hours > 1 ? "s" : ""}`.trim();
   } else {
     if (days >= 1) {
-      const hoursRemain = hours % 24;
+      const hoursRemain = Math.floor((total / (1000 * 60 * 60)) % 24);
       return `${days} day${days > 1 ? "s" : ""} ${
         hoursRemain > 0
           ? hoursRemain + " hour" + (hoursRemain > 1 ? "s" : "")

--- a/patientsearch/src/js/helpers/utility.js
+++ b/patientsearch/src/js/helpers/utility.js
@@ -431,3 +431,35 @@ export function addMamotoTracking(siteId, userId) {
   g.setAttribute("id", "matomoScript");
   headElement.appendChild(g);
 }
+
+/*
+ * @param objDate of type Date object
+ * return text display of time in hour or day
+ */
+export function getTimeAgoDisplay(objDate) {
+  if (!objDate) return "";
+  const today = new Date();
+  const seconds = Math.round((today - objDate) / 1000);
+  const minutes = Math.round(seconds / 60);
+  const hours = Math.round(minutes / 60);
+  const days = Math.round(hours / 24);
+  if (seconds < 5) {
+    return "now";
+  } else if (seconds < 60) {
+    return `< ${seconds} second${seconds > 1 ? "s" : ""}`;
+  } else if (minutes < 60) {
+    return `< 1 hour`;
+  } else if (hours < 24) {
+    return `${hours} hour${hours > 1 ? "s" : ""}`.trim();
+  } else {
+    if (days >= 1) {
+      const hoursRemain = hours % 24;
+      return `${days} day${days > 1 ? "s" : ""} ${
+        hoursRemain > 0
+          ? hoursRemain + " hour" + (hoursRemain > 1 ? "s" : "")
+          : ""
+      }`.trim();
+    }
+    return `${minutes} minute${minutes > 1 ? "s" : ""} ago`;
+  }
+}


### PR DESCRIPTION
Changes needed for story: https://www.pivotaltracker.com/story/show/184551635 to work.

- Add `sortBy` parameter for column config to allow sorting by a custom search field
- Add dataType of `timeAgo` to allow displaying calculation of time elapsed (as needed by the `Time Since Reply` column for Issac

Other changes:
- Address deprecation warnings related to `sorting` & `orderby` column attributes
- Remove hard-coded referenced element, i.e. `patient`

-----------
Things I tried in my instance to add Issac's new `Time Since Reply` column (Please see Hannah's PR [here](https://github.com/uwcirg/isacc-messaging-service/pull/16)):
- Posted custom FHIR Search Parameter:
```
{
  "resourceType" : "SearchParameter",
  "url" : "http://isacc.app/search-param-time-of-last-unfollowedup-message",
  "name" : "SearchParamTimeOfLastUnrespondedMessage",
  "status" : "active",
  "description" : "Search by time of the last message that the patient sent which has not received appropriate followup. The extension/value of the extension does not exist if the patient has no such message.",
  "code" : "time-of-last-unresponded-message",
  "base" : ["Patient"],
  "type" : "date",
  "expression" : "Patient.extension('http://isacc.app/time-of-last-unfollowedup-message').value",
}
```
- Add and update patient with the following extension:
```
    "extension": [
    {
      "url": "http://isacc.app/time-of-last-unfollowedup-message",
      "valueDateTime": "2023-03-02T10:54:18+00:00"
    }
   ]
```
   
- Update the config, `DASHBOARD_COLUMNS` to:
```
[
                {
                    "label": "First Name",
                    "expr": "$.name[0].given[0]",
                },
                {
                    "label": "Last Name",
                    "expr": "$.name[0].family",
                },
                {
                    "label": "Birth Date",
                    "expr": "$.birthDate",
                },
                {
                    "label": "Gender",
                    "expr": "$.gender",
                },
                {
                    "label": "Time Since Reply",
                    "expr": "$.extension[?(@.url=='http://isacc.app/time-of-last-unfollowedup-message')].valueDateTime",
                    "dataType": "timeAgo",
                    "sortBy": "time-of-last-unresponded-message"
                },
            ]
```
- example screenshot after config change:

![timeSinceReply](https://user-images.githubusercontent.com/12942714/222842550-b9e44d12-60eb-400b-8139-e368472ecde1.png)

**Note**  when I tried sorting by the custom search field, `time-of-last-unresponded-message`, only results containing value for the custom search field are returned:
![SortedLastReply](https://user-images.githubusercontent.com/12942714/223801646-b1e00a86-627b-406f-bccb-0745879bb047.png)

Example search URL [here](https://fhir.dcw.dev.cirg.uw.edu/fhir/Patient?_sort=-time-of-last-unresponded-message&_format=json)

Maybe we need to enable ":missing" modifier, it seems disabled by default ?  see [here](https://smilecdr.com/docs/configuration_categories/fhir_performance.html#property-index-missing-search-params)
Also we may need to run the `$reindex` so that all existing patients are searchable via this custom search parameter, not just new patient(s)? see [here](https://smilecdr.com/docs/fhir_repository/search_parameters.html)


