### PR TITLE
make search title configurable

### DIFF
--- a/patientsearch/config.py
+++ b/patientsearch/config.py
@@ -29,6 +29,8 @@ FORBIDDEN_TEXT = os.getenv(
     "Your account is not authorized for access, please contact an administrator",
 )
 
+SEARCH_TITLE_TEXT = os.getenv("SEARCH_TITLE_TEXT", "Patient Search")
+
 DASHBOARD_COLUMNS = json.loads(
     os.getenv(
         "DASHBOARD_COLUMNS",

--- a/patientsearch/src/js/components/Header.js
+++ b/patientsearch/src/js/components/Header.js
@@ -210,7 +210,7 @@ export default function Header() {
         setAppTitle(appSettings["APPLICATION_TITLE"]);
       if (appSettings["PROJECT_NAME"]) {
         setProjectName(appSettings["PROJECT_NAME"]);
-        setDocumentTitle(`${appSettings["PROJECT_NAME"]} Patient Search`);
+        setDocumentTitle(`${appSettings["PROJECT_NAME"]} ${appSettings["SEARCH_TITLE_TEXT"]}`);
         setFavicon(`/static/${appSettings["PROJECT_NAME"]}_favicon.ico`);
       }
     }

--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -999,7 +999,7 @@ export default function PatientListTable() {
     const title = appSettings["SEARCH_TITLE_TEXT"] ? appSettings["SEARCH_TITLE_TEXT"] : null;
     if (!title) return false;
     return <h2>{title}</h2>;
-  }
+  };
 
   const renderPatientSearchRow = () => (
     <table className={classes.filterTable}>

--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -950,6 +950,12 @@ export default function PatientListTable() {
     },
   });
 
+  const renderSearchTitle = () => {
+    const title = appSettings["SEARCH_TITLE_TEXT"] ? appSettings["SEARCH_TITLE_TEXT"] : null;
+    if (!title) return false;
+    return <h2>{title}</h2>;
+  }
+
   const renderPatientSearchRow = () => (
     <table className={classes.filterTable}>
       <tbody>
@@ -1114,7 +1120,7 @@ export default function PatientListTable() {
 
   return (
     <Container className={classes.container} id="patientList">
-      <h2>Patient Search</h2>
+      {renderSearchTitle()}
       <Error message={errorMessage} style={errorStyle} />
       {/* patient search row */}
       {renderPatientSearchRow()}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/184932245
Allows text, e.g. Patient Search, for search (see screenshot) to be configurable:
<img width="966" alt="Screen Shot 2023-04-18 at 3 17 35 PM" src="https://user-images.githubusercontent.com/12942714/232882508-0494bb8f-bb9f-461c-8e61-c32084a41445.png">
In the case for ISACC, that should say "Recipient Search"

Changes include:
A new config variable, `SEARCH_TITLE_TEXT`, is added, to allow the text to be configurable.
