### PR TITLE
practitioner lookup fix

### DIFF
--- a/patientsearch/src/js/context/UserContextProvider.js
+++ b/patientsearch/src/js/context/UserContextProvider.js
@@ -55,10 +55,10 @@ export default function UserContextProvider({ children }) {
         let practitionerId = null;
         const baseURL = "/fhir/Practitioner";
         let requestURLs = [];
-        if (email) requestURLs.push(baseURL + "?email=" + email);
+        if (email) requestURLs.push(baseURL + "?telecom=" + encodeURIComponent(email));
         if (family_name && given_name)
           requestURLs.push(
-            baseURL + "?family=" + family_name + "&given=" + given_name
+            baseURL + "?family=" + encodeURIComponent(family_name) + "&given=" + encodeURIComponent(given_name)
           );
         // try looking up matched practitioner resource by name or email
         if (requestURLs.length > 0) {


### PR DESCRIPTION
Followup fix to https://www.pivotaltracker.com/story/show/184668045

Change include - fix practitioner lookup by email using `telecom` parameter and url-encode the parameter

noting that I did test this fix out against femr shared dev instance