### PR TITLE
add target endpoint for launching client app

### DIFF
--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -597,6 +597,7 @@ def main():
         cache_timeout=-1,
     )
 
+
 @api_blueprint.route("/target", methods=["GET"])
 @oidc.require_login
 def target():

--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -596,3 +596,15 @@ def main():
         "home.html",
         cache_timeout=-1,
     )
+
+@api_blueprint.route("/target", methods=["GET"])
+@oidc.require_login
+def target():
+    return send_from_directory(
+        safe_join(
+            current_app.config.get("STATIC_DIR") or current_app.static_folder,
+            "templates",
+        ),
+        "targetLaunch.html",
+        cache_timeout=-1,
+    )

--- a/patientsearch/src/js/components/ClientAppRedirect.js
+++ b/patientsearch/src/js/components/ClientAppRedirect.js
@@ -40,11 +40,11 @@ export default function ClientAppRedirect() {
   };
 
   useEffect(() => {
-    if (allowToLaunch) {
+    if (targetAppURL) {
       console.log("client app launch URL ", targetAppURL);
       setTimeout(() => (window.location = targetAppURL), 250);
     }
-  }, []);
+  }, [targetAppURL]);
 
   return (
     <div className="content-container">

--- a/patientsearch/src/js/components/ClientAppRedirect.js
+++ b/patientsearch/src/js/components/ClientAppRedirect.js
@@ -1,0 +1,64 @@
+import { useEffect } from "react";
+import CircularProgress from "@material-ui/core/CircularProgress";
+import { useSettingContext } from "../context/SettingContextProvider";
+import { getAppLaunchURL, getUrlParameter } from "../helpers/utility";
+import Alert from "../components/Alert";
+
+export default function ClientAppRedirect() {
+  const settingsCtx = useSettingContext();
+  const appSettings = settingsCtx.appSettings || {};
+  //sample URL: /target?sof_client_id=MESSAGING&patient=2
+  const patientId = getUrlParameter("patient");
+  console.log("Patient Id from URL parameter ", patientId);
+
+  const getTargetClientLaunchURL = () => {
+    const sofClientId = getUrlParameter("sof_client_id");
+    console.log("SOF client ID from URL parameter ", sofClientId);
+    if (!sofClientId) return null;
+
+    const softClients = appSettings["SOF_CLIENTS"];
+    if (!softClients || !softClients.length) return null;
+
+    if (softClients.length === 1) return softClients[0].launch_url;
+
+    const matchedClient = softClients.find(
+      (client) =>
+        String(client.id).toLowerCase() === String(sofClientId).toLowerCase()
+    );
+    if (matchedClient) return matchedClient.launch_url;
+
+    return null;
+  };
+  const targetAppURL = getAppLaunchURL(
+    patientId,
+    getTargetClientLaunchURL(),
+    appSettings
+  );
+  const allowToLaunch = patientId && targetAppURL;
+  const renderError = (message) => {
+    return <Alert message={message} elevation={0}></Alert>;
+  };
+
+  useEffect(() => {
+    if (allowToLaunch) {
+      console.log("client app launch URL ", targetAppURL);
+      setTimeout(() => (window.location = targetAppURL), 250);
+    }
+  }, []);
+
+  return (
+    <div className="content-container">
+      {!patientId && renderError("No patient id specified.")}
+      {!targetAppURL &&
+        renderError(
+          "Invalid or mis-configured SOF client specified.  Unable to retrieve launch URL."
+        )}
+      {allowToLaunch && (
+        <div className="flex">
+          <CircularProgress></CircularProgress>
+          <div>Loading...</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -24,6 +24,7 @@ import * as constants from "../constants/consts";
 import {
   addMamotoTracking,
   fetchData,
+  getAppLaunchURL,
   getLocalDateTimeString,
   getUrlParameter,
   getClientsByRequiredRoles,
@@ -282,16 +283,7 @@ export default function PatientListTable() {
       return "";
     }
     launchParams = launchParams || {};
-    const baseURL = launchParams["launch_url"];
-    const iss = getAppSettingByKey("SOF_HOST_FHIR_URL");
-    const needPatientBanner = getAppSettingByKey("NEED_PATIENT_BANNER");
-    if (!baseURL || !iss) {
-      console.log("Missing ISS launch base URL");
-      return "";
-    }
-    return `${baseURL}?patient=${patientId}&need_patient_banner=${needPatientBanner}&launch=${btoa(
-      JSON.stringify({ a: 1, b: patientId })
-    )}&iss=${encodeURIComponent(iss)}`;
+    return getAppLaunchURL(patientId, launchParams["launch_url"], appSettings);
   };
   const hasSoFClients = () => {
     return appClients && appClients.length > 0;

--- a/patientsearch/src/js/containers/TargetLaunch.js
+++ b/patientsearch/src/js/containers/TargetLaunch.js
@@ -1,0 +1,11 @@
+import React from "react";
+import { render } from "react-dom";
+import ClientAppRedirect from "../components/ClientAppRedirect";
+import Layout from "../layout/Layout";
+
+render(
+  <Layout>
+    <ClientAppRedirect></ClientAppRedirect>
+  </Layout>,
+  document.getElementById("content")
+);

--- a/patientsearch/src/js/helpers/utility.js
+++ b/patientsearch/src/js/helpers/utility.js
@@ -475,3 +475,30 @@ export function getTimeAgoDisplay(objDate) {
     return `${minutes} minute${minutes > 1 ? "s" : ""} ago`;
   }
 }
+
+/*
+ * @param patientId, Id for the patient
+ * @param clientLaunchURL, URL for the client app
+ * @param settings, application settings 
+ * @return {string} url for launching the client app
+ */
+export const getAppLaunchURL = (patientId, clientLaunchURL, settings) => {
+  if (!patientId) {
+    console.log("Missing information: patient Id");
+    return "";
+  }
+  const appSettings = settings ? settings : {};
+  const iss = appSettings["SOF_HOST_FHIR_URL"];
+  const needPatientBanner = appSettings["NEED_PATIENT_BANNER"];
+  if (!clientLaunchURL || !iss) {
+    console.log("Missing ISS launch base URL");
+    return "";
+  }
+  const arrParams = [
+    `patient=${patientId}`,
+    `need_patient_banner=${needPatientBanner}`,
+    `launch=${btoa(JSON.stringify({ a: 1, b: patientId }))}`,
+    `iss=${encodeURIComponent(iss)}`,
+  ];
+  return `${clientLaunchURL}?${arrParams.join("&")}`;
+};

--- a/patientsearch/src/styles/app.scss
+++ b/patientsearch/src/styles/app.scss
@@ -18,6 +18,10 @@ body {
 html {
   scroll-behavior: smooth;
 }
+.content-container {
+  margin-top: 138px;
+  padding: 24px;
+}
 .app-error-container {
   padding: 24px;
   .error {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,8 @@ module.exports = function(_env, argv) {
     entry:  {
       "index" : ["whatwg-fetch", path.join(__dirname, "/patientsearch/src/js/containers/Entry.js")],
       "info": ["whatwg-fetch", path.join(__dirname, "/patientsearch/src/js/containers/Landing.js")],
-      "logout": ["whatwg-fetch", path.join(__dirname, "/patientsearch/src/js/containers/Logout.js")]
+      "logout": ["whatwg-fetch", path.join(__dirname, "/patientsearch/src/js/containers/Logout.js")],
+      "targetLaunch": ["whatwg-fetch", path.join(__dirname, "/patientsearch/src/js/containers/TargetLaunch.js")]
     },
     watchOptions: {
       aggregateTimeout: 300,
@@ -100,6 +101,12 @@ module.exports = function(_env, argv) {
         template: templateFilePath,
         filename: path.join(__dirname, `${templateDirectory}/logout.html`),
         chunks: ["logout"]
+      }),
+      new HtmlWebpackPlugin({
+        title: appTitle,
+        template: templateFilePath,
+        filename: path.join(__dirname, `${templateDirectory}/targetLaunch.html`),
+        chunks: ["targetLaunch"]
       }),
       new webpack.ProvidePlugin({
         React: "react",


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185260711
add support for new `/target` endpoint to re-direct user, post authentication, to a SOF client based on given `sof_client_id` and `patient` query parameters

Example
[example for launching messaging app directly from URL](https://github.com/uwcirg/cosri-patientsearch/assets/12942714/59bbda9b-cba6-42f2-8fe3-62e46cc33122)
