### PR TITLE
My patients filter checkbox: make label text configurable

### DIFF
--- a/patientsearch/config.py
+++ b/patientsearch/config.py
@@ -33,6 +33,8 @@ FORBIDDEN_TEXT = os.getenv(
 
 SEARCH_TITLE_TEXT = os.getenv("SEARCH_TITLE_TEXT", "Patient Search")
 
+MY_PATIENTS_FILTER_LABEL = os.getenv("MY_PATIENTS_FILTER_LABEL", "My Patients")
+
 DASHBOARD_COLUMNS = json.loads(
     os.getenv(
         "DASHBOARD_COLUMNS",

--- a/patientsearch/src/js/components/MyPatientsCheckbox.js
+++ b/patientsearch/src/js/components/MyPatientsCheckbox.js
@@ -20,7 +20,7 @@ const formControlStyles = makeStyles((theme) => {
   };
 });
 
-export default function MyPatientsCheckbox({ shouldDisable, shouldCheck, changeEvent }) {
+export default function MyPatientsCheckbox({ label, shouldDisable, shouldCheck, changeEvent }) {
   const checkboxClasses = checkBoxStyles();
   const formControlClasses = formControlStyles();
   const [state, setState] = useState(shouldCheck);
@@ -46,12 +46,13 @@ export default function MyPatientsCheckbox({ shouldDisable, shouldCheck, changeE
           }}
         />
       }
-      label="My Patients"
+      label={label || "My Patients"}
     />
   );
 }
 
 MyPatientsCheckbox.propTypes = {
+  label: PropTypes.string,
   shouldCheck: PropTypes.bool,
   shouldDisable: PropTypes.bool,
   changeEvent: PropTypes.func,

--- a/patientsearch/src/js/components/MyPatientsCheckbox.js
+++ b/patientsearch/src/js/components/MyPatientsCheckbox.js
@@ -46,13 +46,13 @@ export default function MyPatientsCheckbox({ label, shouldDisable, shouldCheck, 
           }}
         />
       }
-      label={label || "My Patients"}
+      label={label}
     />
   );
 }
 
 MyPatientsCheckbox.propTypes = {
-  label: PropTypes.string,
+  label: PropTypes.string.isRequired,
   shouldCheck: PropTypes.bool,
   shouldDisable: PropTypes.bool,
   changeEvent: PropTypes.func,

--- a/patientsearch/src/js/components/PatientListTable.js
+++ b/patientsearch/src/js/components/PatientListTable.js
@@ -1121,6 +1121,7 @@ export default function PatientListTable() {
     if (!getAppSettingByKey("ENABLE_PROVIDER_FILTER")) return false;
     return (
       <MyPatientsCheckbox
+        label={getAppSettingByKey("MY_PATIENTS_FILTER_LABEL")}
         shouldCheck={filterPatientsByProvider}
         changeEvent={(shouldCheck) => {
           setFilterPatientsByProvider(shouldCheck);


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185407715
Allow the label for the "My Patients" filter checkbox to be configurable via config variable, `MY_PATIENTS_FILTER_LABEL='Recipients I am following'`
For ISACC, the label should say "Recipients I am following", e.g. `MY_PATIENTS_FILTER_LABEL='Recipients I am following'`