### PR TITLE
allow specifying sort via query string

### DIFF
--- a/patientsearch/src/js/components/Header.js
+++ b/patientsearch/src/js/components/Header.js
@@ -164,7 +164,7 @@ export default function Header() {
   const handleHambagaMenuClick = (event) => {
     setAnchorEl(event.currentTarget);
     setOpenPopper((prev) => !prev);
-  } 
+  };
 
   const renderLogoutComponent = () => (
     <div className={classes.buttonContainer}>
@@ -218,7 +218,7 @@ export default function Header() {
         setFavicon(`/static/${appSettings["PROJECT_NAME"]}_favicon.ico`);
       }
     }
-    window.addEventListener("resize", () => setOpenPopper(false))
+    window.addEventListener("resize", () => setOpenPopper(false));
   }, [appSettings]);
 
   const logoutURL = "/logout?user_initiated=true";

--- a/patientsearch/src/js/components/Header.js
+++ b/patientsearch/src/js/components/Header.js
@@ -1,11 +1,16 @@
 import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
+import ExitToAppIcon from "@material-ui/icons/ExitToApp";
+import HowToRegIcon from "@material-ui/icons/HowToReg";
+import MenuIcon from "@material-ui/icons/Menu";
 import AppBar from "@material-ui/core/AppBar";
+import Button from "@material-ui/core/Button";
 import Avatar from "@material-ui/core/Avatar";
 import Box from "@material-ui/core/Box";
-import ExitToAppIcon from "@material-ui/icons/ExitToApp";
+import Fade from "@material-ui/core/Fade";
 import Link from "@material-ui/core/Link";
-import HowToRegIcon from "@material-ui/icons/HowToReg";
+import Popper from "@material-ui/core/Popper";
+import Paper from "@material-ui/core/Paper";
 import Toolbar from "@material-ui/core/Toolbar";
 import Typography from "@material-ui/core/Typography";
 import SiteLogo from "./SiteLogo";
@@ -57,6 +62,24 @@ const useStyles = makeStyles((theme) => ({
     alignItems: "center",
     marginRight: theme.spacing(4),
     marginLeft: theme.spacing(4),
+    [theme.breakpoints.down('sm')]: {
+      display: "none",
+    },
+  },
+  mobileWelcomeContainer: {
+    display: "flex",
+    position: "relative",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    marginRight: theme.spacing(4),
+    marginLeft: theme.spacing(4),
+    [theme.breakpoints.up('md')]: {
+      display: "none",
+    },
+  },
+  menuContainer: {
+    padding: theme.spacing(2)
   },
   welcomeText: {
     marginTop: theme.spacing(0.5),
@@ -105,6 +128,8 @@ export default function Header() {
   const { user: userInfo, error: userError } = useUserContext();
   const [appTitle, setAppTitle] = React.useState("");
   const [projectName, setProjectName] = React.useState("");
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const [openPopper, setOpenPopper] = React.useState(false);
   const hasUserInfo = () => {
     return userInfo && (userInfo.name || userInfo.email);
   };
@@ -135,6 +160,11 @@ export default function Header() {
       return;
     }
   };
+
+  const handleHambagaMenuClick = (event) => {
+    setAnchorEl(event.currentTarget);
+    setOpenPopper((prev) => !prev);
+  } 
 
   const renderLogoutComponent = () => (
     <div className={classes.buttonContainer}>
@@ -188,6 +218,7 @@ export default function Header() {
         setFavicon(`/static/${appSettings["PROJECT_NAME"]}_favicon.ico`);
       }
     }
+    window.addEventListener("resize", () => setOpenPopper(false))
   }, [appSettings]);
 
   const logoutURL = "/logout?user_initiated=true";
@@ -207,6 +238,21 @@ export default function Header() {
           <Box className={classes.welcomeContainer}>
             {renderUserInfoComponent()}
             {renderLogoutComponent()}
+          </Box>
+        )}
+        {!userError && (
+          <Box className={classes.mobileWelcomeContainer}>
+              <Button onClick={handleHambagaMenuClick}><MenuIcon fontSize="large"></MenuIcon></Button>
+              <Popper open={openPopper} anchorEl={anchorEl} placement={"bottom-start"} transition style={{zIndex: 100000}}>
+                {({ TransitionProps }) => (
+                  <Fade {...TransitionProps} timeout={350}>
+                    <Paper className={classes.menuContainer} variant="outlined" square={true}>
+                    {renderUserInfoComponent()}
+                    {renderLogoutComponent()}
+                    </Paper>
+                  </Fade>
+                )}
+              </Popper>
           </Box>
         )}
       </Toolbar>

--- a/patientsearch/src/js/components/LoadingModal.js
+++ b/patientsearch/src/js/components/LoadingModal.js
@@ -48,5 +48,5 @@ export default function LoadingModal(props) {
 }
 
 LoadingModal.propTypes = {
-    open: PropTypes.bool
+  open: PropTypes.bool,
 };

--- a/patientsearch/src/js/components/patientList/PatientList.js
+++ b/patientsearch/src/js/components/patientList/PatientList.js
@@ -80,7 +80,7 @@ export default function PatientListTable() {
       addMamotoTracking(appSettings["MATOMO_SITE_ID"], userName);
     }
     window.addEventListener("unload", () => setOpenLoadingModal(false));
-  }, [userName, appSettings]); //retrieval of settings should occur prior to patient list being rendered/initialized
+  }, [userName, appSettings, setOpenLoadingModal]); //retrieval of settings should occur prior to patient list being rendered/initialized
 
   if (Object.keys(patientListCtx).length === 0)
     return <Error message="patient context error"></Error>;

--- a/patientsearch/src/js/components/patientList/PatientList.js
+++ b/patientsearch/src/js/components/patientList/PatientList.js
@@ -33,6 +33,7 @@ export default function PatientListTable() {
     //states
     errorMessage,
     openLoadingModal,
+    setOpenLoadingModal
   } = usePatientListContext();
 
   const renderTitle = () => {
@@ -78,6 +79,7 @@ export default function PatientListTable() {
     if (appSettings) {
       addMamotoTracking(appSettings["MATOMO_SITE_ID"], userName);
     }
+    window.addEventListener("unload", () => setOpenLoadingModal(false));
   }, [userName, appSettings]); //retrieval of settings should occur prior to patient list being rendered/initialized
 
   if (Object.keys(patientListCtx).length === 0)

--- a/patientsearch/src/js/constants/consts.js
+++ b/patientsearch/src/js/constants/consts.js
@@ -1,5 +1,4 @@
 import { forwardRef, lazy, Suspense } from "react";
-import ArrowDownward from "@material-ui/icons/ArrowDownward";
 import Check from "@material-ui/icons/Check";
 import ChevronLeft from "@material-ui/icons/ChevronLeft";
 import ChevronRight from "@material-ui/icons/ChevronRight";
@@ -7,6 +6,8 @@ import ClearIcon from "@material-ui/icons/Clear";
 import Delete from "@material-ui/icons/Delete";
 import Edit from "@material-ui/icons/Edit";
 import FirstPage from "@material-ui/icons/FirstPage";
+import ArrowDownIcon from '@material-ui/icons/ArrowDropUp';
+import ArrowUpIcon from '@material-ui/icons/ArrowDropDown';
 import LastPage from "@material-ui/icons/LastPage";
 import Search from "@material-ui/icons/Search";
 
@@ -31,7 +32,10 @@ export const tableIcons = {
     <ChevronLeft {...props} ref={ref} />
   )),
   SortArrow: forwardRef((props, ref) => (
-    <ArrowDownward {...props} ref={ref} color="primary" />
+    <div style={{display: "flex", flexDirection:"column"}} {...props} ref={ref} color="primary">
+      <ArrowDownIcon size="small" className="down"></ArrowDownIcon>
+      <ArrowUpIcon size="small" className="up"></ArrowUpIcon>
+    </div>
   )),
   Delete: forwardRef((props, ref) => (
     <Delete {...props} ref={ref} size="small" className="muted">

--- a/patientsearch/src/js/context/PatientListContextProvider.js
+++ b/patientsearch/src/js/context/PatientListContextProvider.js
@@ -986,6 +986,7 @@ export default function PatientListContextProvider({ children }) {
         data,
         errorMessage,
         openLoadingModal,
+        setOpenLoadingModal,
         openLaunchInfoModal,
         pagination,
         paginationDispatch,

--- a/patientsearch/src/js/context/PatientListContextProvider.js
+++ b/patientsearch/src/js/context/PatientListContextProvider.js
@@ -137,14 +137,20 @@ export default function PatientListContextProvider({ children }) {
     });
     const sortByQueryString = getUrlParameter("sort_by");
     const sortDirectionQueryString = getUrlParameter("sort_direction");
+    // see if a column matched the sort field name specified by URL query string
     const matchedColumn = returnColumns.find(
       (column) => column.field === sortByQueryString
     );
     if (matchedColumn) {
+      // if matched column found, set it as the default sort column
       returnColumns = returnColumns.map((column) => {
         if (column.field === matchedColumn.field) {
+          // set sort direction if specified via URL query string
+          // otherwise use the column's default sort if available (otherwise 'asc' by default)
           column.defaultSort = sortDirectionQueryString
             ? sortDirectionQueryString
+            : column.defaultSort
+            ? column.defaultSort
             : "asc";
         } else {
           column.defaultSort = null;

--- a/patientsearch/src/js/context/PatientListContextProvider.js
+++ b/patientsearch/src/js/context/PatientListContextProvider.js
@@ -123,7 +123,7 @@ export default function PatientListContextProvider({ children }) {
         hidden: true,
         expr: "$.id",
       });
-    return cols.map((column) => {
+    let returnColumns = cols.map((column) => {
       const fieldName = column.label.toLowerCase().replace(/\s/g, "_");
       column.title = column.label;
       column.field = fieldName;
@@ -135,6 +135,24 @@ export default function PatientListContextProvider({ children }) {
       );
       return column;
     });
+    const sortByQueryString = getUrlParameter("sort_by");
+    const sortDirectionQueryString = getUrlParameter("sort_direction");
+    const matchedColumn = returnColumns.find(
+      (column) => column.field === sortByQueryString
+    );
+    if (matchedColumn) {
+      returnColumns = returnColumns.map((column) => {
+        if (column.field === matchedColumn.field) {
+          column.defaultSort = sortDirectionQueryString
+            ? sortDirectionQueryString
+            : "asc";
+        } else {
+          column.defaultSort = null;
+        }
+        return column;
+      });
+    }
+    return returnColumns;
   };
   const needExternalAPILookup = () => {
     return getAppSettingByKey("EXTERNAL_FHIR_API");
@@ -425,8 +443,8 @@ export default function PatientListContextProvider({ children }) {
     let sortField = null,
       sortDirection = null;
     if (orderByCollection && orderByCollection.length) {
-      const orderField = orderByCollection[0];
       const cols = getColumns();
+      const orderField = orderByCollection[0];
       const orderByField = cols[orderField.orderBy]; // orderBy is the index of the column
       if (orderByField) {
         const matchedColumn = cols.filter(

--- a/patientsearch/src/js/context/SettingContextProvider.js
+++ b/patientsearch/src/js/context/SettingContextProvider.js
@@ -17,7 +17,7 @@ export default function SettingContextProvider({ children }) {
       if (!hasAppSettings()) return "";
       return appSettings[key];
     },
-    [appSettings]
+    [appSettings, hasAppSettings]
   );
   useEffect(() => {
     getSettings((data) => {

--- a/patientsearch/src/styles/app.scss
+++ b/patientsearch/src/styles/app.scss
@@ -278,7 +278,7 @@ button.disabled:focus,
       tr {
         position: relative;
         &:hover {
-          filter: brightness(1.2);
+          filter: brightness(0.99);
         }
         td:last-child {
           min-width: 96px;

--- a/patientsearch/src/styles/app.scss
+++ b/patientsearch/src/styles/app.scss
@@ -2,7 +2,8 @@ $color-blue: #00838f;
 $color-blue-light: #46777f;
 $color-success: green;
 $color-warning: #9a4d0d;
-$color-muted: #777;
+$color-less-muted: rgba(0, 0, 0, 0.8);
+$color-muted: rgba(0, 0, 0, 0.54);
 $color-muter: rgba(165, 158, 158, 0.64);
 $color-error: #c91616;
 $color-label: #525050;
@@ -55,6 +56,10 @@ html {
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
+}
+.flex-column {
+  display: flex;
+  flex-direction: column;
 }
 .flex-center {
   display: flex;
@@ -160,23 +165,6 @@ html {
 img[disabled] {
   display: none;
 }
-.MuiTypography-h6 {
-  font-size: 1.02rem !important;
-}
-.MuiTableCell-body {
-  .MuiTypography-h6 {
-    width: 100%;
-    max-width: 100%;
-  }
-}
-@media (min-width: 699px) {
-  .MuiTableCell-body {
-    .MuiTypography-h6 {
-      width: 448px;
-      max-width: 100%;
-    }
-  }
-}
 tr:empty {
   height: 0 !important;
 }
@@ -214,6 +202,98 @@ button.disabled:focus,
     color: #FFF;
   }
 }
+.MuiTypography-h6 {
+  font-size: 1.02rem !important;
+}
+.MuiTableCell-body {
+  .MuiTypography-h6 {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+@media (min-width: 699px) {
+  .MuiTableCell-body {
+    .MuiTypography-h6 {
+      width: 448px;
+      max-width: 100%;
+    }
+  }
+}
+/* Make both ascending and descending sort arrows always visible */
+//.MuiTableSortLabel-iconDirectionAsc ascending class
+//.MuiTableSortLabel-iconDirectionDesc descending class
+
+.MuiTableSortLabel-icon {
+  opacity: 1 !important;
+  visibility: visible !important;
+  transform: none !important;
+  svg {
+    &:first-of-type {
+      position: relative;
+      top: 8px;
+    }
+    &:last-of-type {
+      position: relative;
+      top: -8px;
+    }
+  }
+}
+.MuiTableSortLabel-root.MuiTableSortLabel-active {
+  .MuiTableSortLabel-iconDirectionAsc {
+    .up {
+      fill: $color-muter !important;
+    }
+    .down {
+      fill: $color-less-muted !important;
+    }
+
+  }
+  .MuiTableSortLabel-iconDirectionDesc {
+    .down {
+      fill: $color-muter !important;
+    }
+    .up {
+      fill: $color-less-muted !important;
+    }
+  }
+}
+
+#patientList {
+  input,
+  .MuiInputLabel-formControl {
+    font-size: $small-font-size;
+  }
+  .main {
+    tr {
+      td:last-child {
+        min-width: 96px;
+      }
+    }
+  }
+  table {
+    position: relative;
+    overflow: hidden;
+  }
+}
+#patientListPagination {
+  .MuiSelect-root {
+    min-width: 32px;
+  }
+  .MuiSelect-icon {
+    right: 20px;
+  }
+  .MuiSelect-select.MuiSelect-select {
+    padding-right: 4px !important;
+  }
+}
+
+/*
+ * hide the Lage Page arrow on patient list table
+ */
+.MuiTableRow-footer [title='Last Page'] {
+  display: none !important;
+}
+
 .spinner {
   position: fixed;
   left: 0;
@@ -280,42 +360,6 @@ button.disabled:focus,
 .bounce2 {
   -webkit-animation-delay: -0.16s;
   animation-delay: -0.16s;
-}
-
-#patientList {
-  input,
-  .MuiInputLabel-formControl {
-    font-size: $small-font-size;
-  }
-  .main {
-    tr {
-      td:last-child {
-        min-width: 96px;
-      }
-    }
-  }
-  table {
-    position: relative;
-    overflow: hidden;
-  }
-}
-#patientListPagination {
-  .MuiSelect-root {
-    min-width: 32px;
-  }
-  .MuiSelect-icon {
-    right: 20px;
-  }
-  .MuiSelect-select.MuiSelect-select {
-    padding-right: 4px !important;
-  }
-}
-
-/*
- * hide the Lage Page arrow on patient list table
- */
-.MuiTableRow-footer [title='Last Page'] {
-  display: none !important;
 }
 
 /*

--- a/patientsearch/src/styles/app.scss
+++ b/patientsearch/src/styles/app.scss
@@ -264,9 +264,15 @@ button.disabled:focus,
     font-size: $small-font-size;
   }
   .main {
-    tr {
-      td:last-child {
-        min-width: 96px;
+    tbody {
+      tr {
+        position: relative;
+        &:hover {
+          filter: brightness(1.2);
+        }
+        td:last-child {
+          min-width: 96px;
+        }
       }
     }
   }

--- a/patientsearch/src/styles/app.scss
+++ b/patientsearch/src/styles/app.scss
@@ -228,6 +228,10 @@ button.disabled:focus,
   visibility: visible !important;
   transform: none !important;
   svg {
+    opacity: 0.6;
+    &:hover {
+      opacity: 1 !important;
+    }
     &:first-of-type {
       position: relative;
       top: 8px;
@@ -236,6 +240,12 @@ button.disabled:focus,
       position: relative;
       top: -8px;
     }
+  }
+}
+.MuiTableSortLabel-root {
+  &:hover {
+    opacity: 1 !important;
+    color: #444 !important;
   }
 }
 .MuiTableSortLabel-root.MuiTableSortLabel-active {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185953047 - Patient list - add param for sort on load

Changes include 
- allowing specifying `sort_by` (for the name of the sort field) and/or `sort_direction` ("asc" o "desc") in URL query strings
- allow sort arrow icons to be visible on all columns (see screenshot):

![Screenshot 2023-09-01 at 2 17 46 PM](https://github.com/uwcirg/cosri-patientsearch/assets/12942714/1d45afda-60dd-4aa5-b3b0-d0a620460913)


Examples for suppling `sort_by` and `sort_direction` in URL as query strings:
https://clone-dev.cirg.washington.edu/home?sort_by=time_since_reply  (default sort direction is `asc`)
produces:
![Screenshot 2023-09-01 at 2 23 26 PM](https://github.com/uwcirg/cosri-patientsearch/assets/12942714/ad450809-5dff-42e1-98f2-fa1a642354fc)


https://clone-dev.cirg.washington.edu/home?sort_by=time_since_reply&sort_direction=desc
produces:
![Screenshot 2023-09-01 at 2 23 38 PM](https://github.com/uwcirg/cosri-patientsearch/assets/12942714/cf88973b-05df-466c-9858-0b188f8639c1)


I have also tried:
https://clone-dev.cirg.washington.edu/home?sort_by=birth_date
https://clone-dev.cirg.washington.edu/home?sort_by=first_name
https://clone-dev.cirg.washington.edu/home?sort_by=last_name

This works if I go to `https://[host]/home?sort_by=[sort field name]` before or after authentication

