### PR TITLE
fix issue with broken redirect - pass correct parameter

### DIFF
--- a/patientsearch/src/js/components/ClientAppRedirect.js
+++ b/patientsearch/src/js/components/ClientAppRedirect.js
@@ -31,8 +31,10 @@ export default function ClientAppRedirect() {
   };
   const targetAppURL = getAppLaunchURL(
     patientId,
-    getTargetClientLaunchURL(),
-    appSettings
+    {
+      ...appSettings,
+      "launch_url": getTargetClientLaunchURL()
+    }
   );
   const allowToLaunch = patientId && targetAppURL;
   const renderError = (message) => {


### PR DESCRIPTION
Fix issue seen when redirecting to the messaging client via a link, e.g.:
https://femr.isacc.dev.cirg.uw.edu/target?sof_client_id=MESSAGING&patient=1
![Screen Shot 2023-09-13 at 1 00 27 PM](https://github.com/uwcirg/cosri-patientsearch/assets/12942714/9ac2eff2-e830-4fc9-a564-e8c77bbc95a5)

change is to pass in correct parameter due to a change [here](https://github.com/uwcirg/cosri-patientsearch/blob/418844ce04048422c918910137753bc885f3aaec/patientsearch/src/js/helpers/utility.js#L498)
