### PR TITLE
Next Message column - do not display dates in past

### DIFF
--- a/patientsearch/src/js/context/PatientListContextProvider.js
+++ b/patientsearch/src/js/context/PatientListContextProvider.js
@@ -16,6 +16,7 @@ import {
   getClientsByRequiredRoles,
   getPatientIdsByCareTeamParticipant,
   getTimeAgoDisplay,
+  isInPast,
   isString,
   putPatientData,
   getUrlParameter,
@@ -406,11 +407,15 @@ export default function PatientListContextProvider({ children }) {
             }
             let value =
               nodes && nodes.length ? nodes[nodes.length - 1].value : null;
+
             if (dataType === "date") {
               value = value ? getLocalDateTimeString(value) : "--";
             }
             if (dataType === "timeago" && value) {
               value = value ? getTimeAgoDisplay(new Date(value)) : "--";
+            }
+            if (dataType === "nextscheduleddate") {
+              value = isInPast(value) ? "--": getLocalDateTimeString(value);
             }
             if (col.field) rowData[col.field] = value;
           });

--- a/patientsearch/src/js/context/PatientListContextProvider.js
+++ b/patientsearch/src/js/context/PatientListContextProvider.js
@@ -414,7 +414,8 @@ export default function PatientListContextProvider({ children }) {
             if (dataType === "timeago" && value) {
               value = value ? getTimeAgoDisplay(new Date(value)) : "--";
             }
-            if (dataType === "nextscheduleddate") {
+            if (col.field === "next_message") {
+              // TODO maybe a specific data type to handle not displaying past message?
               value = isInPast(value) ? "--": getLocalDateTimeString(value);
             }
             if (col.field) rowData[col.field] = value;

--- a/patientsearch/src/js/helpers/utility.js
+++ b/patientsearch/src/js/helpers/utility.js
@@ -456,6 +456,18 @@ export function addMamotoTracking(siteId, userId) {
 }
 
 /*
+ * @param dateString of type String
+ * @returns true if supplied dateString is determined to be less than today's date otherwise false 
+ */
+export function isInPast(dateString) {
+  if (!dateString) return false;
+  const today = new Date();
+  const targetDate = new Date(dateString);
+  if (!isValid(targetDate)) return false;
+  return targetDate < today;
+}
+
+/*
  * @param objDate of type Date object
  * @returns text display of time ago as string e.g. < 50 seconds, < 1 hour, 1 day 2 hours, 3 hours, 3 days
  */


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/183693507
This fix address the issue where past dates were displayed on the `Next Message` column.
With this fix, only present/future date(s) will display.  Example screenshot after fix:
<img width="1194" alt="Screen Shot 2023-10-19 at 4 57 24 PM" src="https://github.com/uwcirg/cosri-patientsearch/assets/12942714/faafdf17-54da-488a-8c23-56f71f932499">
