### PR TITLE
fix method for external search API call

### DIFF
--- a/patientsearch/src/js/context/PatientListContextProvider.js
+++ b/patientsearch/src/js/context/PatientListContextProvider.js
@@ -747,7 +747,8 @@ export default function PatientListContextProvider({ children }) {
         }),
         {
           ...searchParams,
-          method: "GET",
+          // external search API allowable method is PUT
+          method: needExternalAPILookup() ? "PUT": "GET",
         },
         (e) => handleErrorCallback(e)
       );


### PR DESCRIPTION
side effect from changes [here](https://github.com/uwcirg/cosri-patientsearch/pull/204)
For external search(for PDMP), the allowable method is PUT