### PR TITLE
Followed recipients query fix

### DIFF
--- a/patientsearch/src/js/context/PatientListContextProvider.js
+++ b/patientsearch/src/js/context/PatientListContextProvider.js
@@ -119,13 +119,6 @@ export default function PatientListContextProvider({ children }) {
       }).length > 0
     );
   };
-  const _addDataRow = (rowData) => {
-    if (!rowData || !rowData.id) return false;
-    let newData = _formatData(rowData);
-    if (newData && !existsIndata(newData[0])) {
-      setData([newData[0], ...data]);
-    }
-  };
   const getColumns = () => {
     const configColumns = getAppSettingByKey("DASHBOARD_COLUMNS");
     const defaultSearchFields = constants.defaultSearchableFields;

--- a/patientsearch/src/js/context/PatientListContextProvider.js
+++ b/patientsearch/src/js/context/PatientListContextProvider.js
@@ -111,14 +111,6 @@ export default function PatientListContextProvider({ children }) {
   const [noDataText, setNoDataText] = React.useState("No record found.");
   const [filterByTestPatients, setFilterByTestPatients] = React.useState(false);
 
-  const existsIndata = (rowData) => {
-    if (!data || !rowData) return false;
-    return (
-      data.filter((item) => {
-        return parseInt(item.id) === parseInt(rowData.id);
-      }).length > 0
-    );
-  };
   const getColumns = () => {
     const configColumns = getAppSettingByKey("DASHBOARD_COLUMNS");
     const defaultSearchFields = constants.defaultSearchableFields;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/188016941
- Add query for Patient resources for patient(s) whose general practitioner is the user.  This may be the case where the patient is assigned the practitioner but doesn't have active careplan,e.g. careplan revoked.
- Bump up `_count`, pagination may be a concern for large number of patients the user is following. 