### PR TITLE
bugfix - inactive patient search query

### DIFF
--- a/patientsearch/src/js/components/patientList/FilterRow.js
+++ b/patientsearch/src/js/components/patientList/FilterRow.js
@@ -121,6 +121,7 @@ export default forwardRef((props, ref) => {
       e.stopPropagation();
     }
     if (pressedKey === "enter") {
+      if (!hasCompleteFilters()) return;
       handleSearch(getFilterData());
       return;
     }

--- a/patientsearch/src/js/helpers/utility.js
+++ b/patientsearch/src/js/helpers/utility.js
@@ -694,6 +694,6 @@ export function getInactiveEntriesFromPatientBundle(bundle) {
     if (typeof item.active === "undefined") {
       return true;
     }
-    return String(item.active).toLowerCase() === "true";
+    return String(item.active).toLowerCase() !== "true";
   });
 }


### PR DESCRIPTION
fix bug from recent refactor (see [here](https://github.com/uwcirg/cosri-patientsearch/blob/develop/patientsearch/src/js/helpers/utility.js#L697))  See [Slack convo](https://cirg.slack.com/archives/C01P9V67NMA/p1725993860558159?thread_ts=1725918659.467719&cid=C01P9V67NMA)

- Fix inactive patient query (change `===` to `!==` when checking 'active' flag

Other fix
- return before launching app if filters incomplete upon hitting "Enter" key