### PR TITLE
add config to control adding local patients when not in EXTERNAL

### DIFF
--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -532,7 +532,8 @@ def external_search(resource_type):
     active_patient_flag = current_app.config.get("ACTIVE_PATIENT_FLAG")
     reactivate_patient = current_app.config.get("REACTIVATE_PATIENT")
     only_create_patient_if_found_external = current_app.config.get(
-        "ONLY_CREATE_PATIENT_IF_FOUND_EXTERNAL")
+        "ONLY_CREATE_PATIENT_IF_FOUND_EXTERNAL"
+    )
 
     params = dict(deepcopy(request.args))  # Necessary on ImmutableMultiDict
     if active_patient_flag and resource_type == "Patient":
@@ -597,7 +598,9 @@ def external_search(resource_type):
                 level="warn",
             )
 
-    allow_local_creation = not (only_create_patient_if_found_external and not external_match_count)
+    allow_local_creation = not (
+        only_create_patient_if_found_external and not external_match_count
+    )
     if not local_fhir_patient and allow_local_creation:
         # Add at this time in the local (HAPI) store
         try:

--- a/patientsearch/api.py
+++ b/patientsearch/api.py
@@ -531,6 +531,8 @@ def external_search(resource_type):
     token = validate_auth()
     active_patient_flag = current_app.config.get("ACTIVE_PATIENT_FLAG")
     reactivate_patient = current_app.config.get("REACTIVATE_PATIENT")
+    only_create_patient_if_found_external = current_app.config.get(
+        "ONLY_CREATE_PATIENT_IF_FOUND_EXTERNAL")
 
     params = dict(deepcopy(request.args))  # Necessary on ImmutableMultiDict
     if active_patient_flag and resource_type == "Patient":
@@ -595,7 +597,8 @@ def external_search(resource_type):
                 level="warn",
             )
 
-    if not local_fhir_patient:
+    allow_local_creation = not (only_create_patient_if_found_external and not external_match_count)
+    if not local_fhir_patient and allow_local_creation:
         # Add at this time in the local (HAPI) store
         try:
             patient = new_resource_hook(patient)

--- a/patientsearch/config.py
+++ b/patientsearch/config.py
@@ -141,5 +141,6 @@ REQUIRED_ROLES = json.loads(os.getenv("REQUIRED_ROLES", "[]"))
 UDS_LAB_TYPES = json.loads(os.getenv("UDS_LAB_TYPES", "[]"))
 ACTIVE_PATIENT_FLAG = os.getenv("ACTIVE_PATIENT_FLAG", "false").lower() == "true"
 REACTIVATE_PATIENT = os.getenv("REACTIVATE_PATIENT", "false").lower() == "true"
-ONLY_CREATE_PATIENT_IF_FOUND_EXTERNAL = os.getenv(
-    "ONLY_CREATE_PATIENT_IF_FOUND_EXTERNAL", "false").lower() == "true"
+ONLY_CREATE_PATIENT_IF_FOUND_EXTERNAL = (
+    os.getenv("ONLY_CREATE_PATIENT_IF_FOUND_EXTERNAL", "false").lower() == "true"
+)

--- a/patientsearch/config.py
+++ b/patientsearch/config.py
@@ -141,3 +141,5 @@ REQUIRED_ROLES = json.loads(os.getenv("REQUIRED_ROLES", "[]"))
 UDS_LAB_TYPES = json.loads(os.getenv("UDS_LAB_TYPES", "[]"))
 ACTIVE_PATIENT_FLAG = os.getenv("ACTIVE_PATIENT_FLAG", "false").lower() == "true"
 REACTIVATE_PATIENT = os.getenv("REACTIVATE_PATIENT", "false").lower() == "true"
+ONLY_CREATE_PATIENT_IF_FOUND_EXTERNAL = os.getenv(
+    "ONLY_CREATE_PATIENT_IF_FOUND_EXTERNAL", "false").lower() == "true"


### PR DESCRIPTION
fix for https://www.pivotaltracker.com/story/show/188254232 
new config flag `ONLY_CREATE_PATIENT_IF_FOUND_EXTERNAL` to toggle creation of patients when found/not found in EXTERNAL (i.e. PDMP) search.