### PR TITLE
Fix frontend API call error handling

### DIFF
--- a/patientsearch/src/js/constants/consts.js
+++ b/patientsearch/src/js/constants/consts.js
@@ -155,3 +155,7 @@ export const REALM_ACCESS_TOKEN_KEY = "realm_access";
 export const MAX_MAIN_TABLE_WIDTH = "1280px";
 export const FOLLOWING_FLAG = "following";
 export const MIN_QUERY_COUNT = 500;
+export const HTTP_FORBIDDEN_STATUS_CODE = 403;
+export const HTTP_UNAUTHORIZED_STATUS_CODE = 401;
+export const FORBIDDEN_LOGOUT_URL = "/logout?forbidden=true";
+export const UNAUTHORIZED_LOGOUT_URL = "/logout?unauthorized=true";

--- a/patientsearch/src/js/constants/consts.js
+++ b/patientsearch/src/js/constants/consts.js
@@ -155,7 +155,13 @@ export const REALM_ACCESS_TOKEN_KEY = "realm_access";
 export const MAX_MAIN_TABLE_WIDTH = "1280px";
 export const FOLLOWING_FLAG = "following";
 export const MIN_QUERY_COUNT = 500;
-export const HTTP_FORBIDDEN_STATUS_CODE = 403;
-export const HTTP_UNAUTHORIZED_STATUS_CODE = 401;
-export const FORBIDDEN_LOGOUT_URL = "/logout?forbidden=true";
-export const UNAUTHORIZED_LOGOUT_URL = "/logout?unauthorized=true";
+export const objErrorStatus = {
+  401: {
+    text: "Unauthorized.",
+    logoutURL: "/logout?unauthorized=true",
+  },
+  403: {
+    text: "Forbidden.",
+    logoutURL: "/logout?forbidden=true",
+  }
+};

--- a/patientsearch/src/js/containers/Logout.js
+++ b/patientsearch/src/js/containers/Logout.js
@@ -8,10 +8,12 @@ import { getUrlParameter } from "../helpers/utility";
 import { useSettingContext } from "../context/SettingContextProvider";
 import "../../styles/app.scss";
 
+
+const isForbidden = getUrlParameter("forbidden");
 // Error message, e.g. forbidden error
 const AlertMessage = () => {
   const appSettings = useSettingContext().appSettings;
-  if (!getUrlParameter("forbidden")) return ""; // look for forbidden message for now, can be others as well
+  if (!isForbidden) return ""; // look for forbidden message for now, can be others as well
   const message =
     appSettings && appSettings["FORBIDDEN_TEXT"]
       ? appSettings["FORBIDDEN_TEXT"]
@@ -41,15 +43,17 @@ render(
       </Typography>
       <AlertMessage></AlertMessage>
       <br />
-      <Button
-        color="primary"
-        href="/home"
-        align="center"
-        variant="outlined"
-        size="large"
-      >
-        Click here to log in
-      </Button>
+      {!isForbidden && 
+        <Button
+          color="primary"
+          href="/home"
+          align="center"
+          variant="outlined"
+          size="large"
+        >
+          Click here to log in
+        </Button>
+      }
     </div>
   </Layout>,
   document.getElementById("content")

--- a/patientsearch/src/js/context/PatientListContextProvider.js
+++ b/patientsearch/src/js/context/PatientListContextProvider.js
@@ -263,14 +263,10 @@ export default function PatientListContextProvider({ children }) {
     setNoDataText(text);
   };
   const handleErrorCallback = (e) => {
-    if (e && e.status === constants.HTTP_UNAUTHORIZED_STATUS_CODE) {
-      setErrorMessage("Unauthorized. Logging out...");
-      window.location = constants.UNAUTHORIZED_LOGOUT_URL;
-      return;
-    }
-    if (e && e.status === constants. HTTP_FORBIDDEN_STATUS_CODE) {
-      setErrorMessage("Forbidden. Logging out...");
-      window.location = constants.FORBIDDEN_LOGOUT_URL;
+    const oStatus = constants.objErrorStatus[parseInt(e?.status)];
+    if (oStatus) {
+      setErrorMessage(`${oStatus.text}. Logging out...`);
+      window.location = oStatus.logoutURL;
       return;
     }
     setErrorMessage(

--- a/patientsearch/src/js/context/PatientListContextProvider.js
+++ b/patientsearch/src/js/context/PatientListContextProvider.js
@@ -1067,17 +1067,8 @@ export default function PatientListContextProvider({ children }) {
         })
         .catch((error) => {
           console.log("Failed to retrieve data", error);
-          //unauthorized error
+          //display error message or redirect based on error status
           handleErrorCallback(error);
-          setErrorMessage(
-            `Error retrieving data: ${
-              typeof error === "string"
-                ? error
-                : error && error.status
-                ? "Error status " + error.status
-                : error
-            }`
-          );
           resolve(defaults);
         });
     });

--- a/patientsearch/src/js/context/PatientListContextProvider.js
+++ b/patientsearch/src/js/context/PatientListContextProvider.js
@@ -263,14 +263,14 @@ export default function PatientListContextProvider({ children }) {
     setNoDataText(text);
   };
   const handleErrorCallback = (e) => {
-    if (e && e.status === 401) {
-      setErrorMessage("Unauthorized.");
-      window.location = "/logout?unauthorized=true";
+    if (e && e.status === constants.HTTP_UNAUTHORIZED_STATUS_CODE) {
+      setErrorMessage("Unauthorized. Logging out...");
+      window.location = constants.UNAUTHORIZED_LOGOUT_URL;
       return;
     }
-    if (e && e.status === 403) {
-      setErrorMessage("Forbidden.");
-      window.location = "/logout?forbidden=true";
+    if (e && e.status === constants. HTTP_FORBIDDEN_STATUS_CODE) {
+      setErrorMessage("Forbidden. Logging out...");
+      window.location = constants.FORBIDDEN_LOGOUT_URL;
       return;
     }
     setErrorMessage(

--- a/patientsearch/src/js/context/PatientListContextProvider.js
+++ b/patientsearch/src/js/context/PatientListContextProvider.js
@@ -1067,7 +1067,7 @@ export default function PatientListContextProvider({ children }) {
         })
         .catch((error) => {
           console.log("Failed to retrieve data", error);
-          //display error message or redirect based on error status
+          // set error message or redirect based on error status
           handleErrorCallback(error);
           resolve(defaults);
         });

--- a/patientsearch/src/js/context/UserContextProvider.js
+++ b/patientsearch/src/js/context/UserContextProvider.js
@@ -14,10 +14,7 @@ import {
 } from "../helpers/utility";
 import {
   noCacheParam,
-  HTTP_FORBIDDEN_STATUS_CODE,
-  HTTP_UNAUTHORIZED_STATUS_CODE,
-  FORBIDDEN_LOGOUT_URL,
-  UNAUTHORIZED_LOGOUT_URL,
+  objErrorStatus
  } from "../constants/consts";
 const UserContext = React.createContext({});
 /*
@@ -28,12 +25,9 @@ export default function UserContextProvider({ children }) {
   const [errorMessage, setErrorMessage] = useState("");
   const handleErrorCallback = (e) => {
     const status = parseInt(e?.status);
-    if (status === HTTP_UNAUTHORIZED_STATUS_CODE) {
-      window.location = UNAUTHORIZED_LOGOUT_URL;
-      return;
-    }
-    if (status === HTTP_FORBIDDEN_STATUS_CODE) {
-      window.location = FORBIDDEN_LOGOUT_URL;
+    const oStatus = objErrorStatus[status];
+    if (oStatus) {
+      window.location = oStatus.logoutURL;
       return;
     }
     setErrorMessage(

--- a/patientsearch/src/js/helpers/utility.js
+++ b/patientsearch/src/js/helpers/utility.js
@@ -90,6 +90,10 @@ export async function fetchData(url, params, errorCallback) {
     console.log("no results returned ", results);
     if (!results.ok) {
       console.log("Error results ", results);
+      if (results && results.status) {
+        // raise error here to allow callee to catch it as needed
+        throw results;
+      }
       const errorMessage =
         json && json.message
           ? json.message


### PR DESCRIPTION
see Slack convo [here](https://cirg.slack.com/archives/C01P9V67NMA/p1738866927545329?thread_ts=1738866788.001229&cid=C01P9V67NMA)

- fix frontend error handling of API call by catching the error and behaving appropriately based error status.

User will be redirected and appropriate message will display if 403 error is raised. See screenshot:
![Screenshot 2025-02-06 at 11 52 32 AM](https://github.com/user-attachments/assets/472ab672-7415-47ec-b150-edd6afdf6f30)
